### PR TITLE
fix imports and allow configuration via args

### DIFF
--- a/dojo/indicators/country.csv
+++ b/dojo/indicators/country.csv
@@ -1,0 +1,247 @@
+country_name,Alpha-2_Code,Alpha-3_Code,ISO_Numeric-3_Code
+Afghanistan,AF,AFG,4
+Åland Islands,AX,ALA,248
+Albania,AL,ALB,8
+Algeria,DZ,DZA,12
+American Samoa,AS,ASM,16
+Andorra,AD,AND,20
+Angola,AO,AGO,24
+Anguilla,AI,AIA,660
+Antigua and Barbuda,AG,ATG,28
+Argentina,AR,ARG,32
+Armenia,AM,ARM,51
+Aruba,AW,ABW,533
+Australia,AU,AUS,36
+Austria,AT,AUT,40
+Azerbaijan,AZ,AZE,31
+Bahamas,BS,BHS,44
+Bahrain,BH,BHR,48
+Bangladesh,BD,BGD,50
+Barbados,BB,BRB,52
+Belarus,BY,BLR,112
+Belgium,BE,BEL,56
+Belize,BZ,BLZ,84
+Benin,BJ,BEN,204
+Bermuda,BM,BMU,60
+Bhutan,BT,BTN,64
+Bolivia,BO,BOL,68
+"Bonaire, Sint Eustatius, and Saba",BQ,BES,535
+Bosnia and Herzegovina,BA,BIH,70
+Botswana,BW,BWA,72
+Brazil,BR,BRA,76
+British Indian Ocean Territory,IO,IOT,86
+British Virgin Islands,VG,VGB,92
+Brunei,BN,BRN,96
+Bulgaria,BG,BGR,100
+Burkina Faso,BF,BFA,854
+Burundi,BI,BDI,108
+Cabo Verde,CV,CPV,132
+Cambodia,KH,KHM,116
+Cameroon,CM,CMR,120
+Canada,CA,CAN,124
+Cayman Islands,KY,CYM,136
+Central African Republic,CF,CAF,140
+Chad,TD,TCD,148
+Chile,CL,CHL,152
+China,CN,CHN,156
+Christmas Island,CX,CXR,162
+Cocos (Keeling) Islands,CC,CCK,166
+Colombia,CO,COL,170
+Comoros,KM,COM,174
+Congo,CG,COG,178
+"Congo, Democratic Republic of the",CD,COD,180
+Cook Islands,CK,COK,184
+Costa Rica,CR,CRI,188
+Côte d'Ivoire,CI,CIV,384
+Croatia,HR,HRV,191
+Cuba,CU,CUB,192
+Curaçao,CW,CUW,531
+Cyprus,CY,CYP,196
+Czechia,CZ,CZE,203
+Denmark,DK,DNK,208
+Djibouti,DJ,DJI,262
+Dominica,DM,DMA,212
+Dominican Republic,DO,DOM,214
+Ecuador,EC,ECU,218
+Egypt,EG,EGY,818
+El Salvador,SV,SLV,222
+Equatorial Guinea,GQ,GNQ,226
+Eritrea,ER,ERI,232
+Estonia,EE,EST,233
+Eswatini,SZ,SWZ,748
+Ethiopia,ET,ETH,231
+Falkland Islands,FK,FLK,238
+Faroe Islands,FO,FRO,234
+Fiji,FJ,FJI,242
+Finland,FI,FIN,246
+France,FR,FRA,250
+French Guiana,GF,GUF,254
+French Polynesia,PF,PYF,258
+Gabon,GA,GAB,266
+Gambia,GM,GMB,270
+Georgia,GE,GEO,268
+Germany,DE,DEU,276
+Ghana,GH,GHA,288
+Gibraltar,GI,GIB,292
+Greece,GR,GRC,300
+Greenland,GL,GRL,304
+Grenada,GD,GRD,308
+Guadeloupe,GP,GLP,312
+Guam,GU,GUM,316
+Guatemala,GT,GTM,320
+Guernsey,GG,GGY,831
+Guinea,GN,GIN,324
+Guinea-Bissau,GW,GNB,624
+Guyana,GY,GUY,328
+Haiti,HT,HTI,332
+Holy See (Vatican City State),VA,VAT,336
+Honduras,HN,HND,340
+Hong Kong,HK,HKG,344
+Hungary,HU,HUN,348
+Iceland,IS,ISL,352
+India,IN,IND,356
+Indonesia,ID,IDN,360
+Iran,IR,IRN,364
+Iraq,IQ,IRQ,368
+Ireland,IE,IRL,372
+Isle of Man,IM,IMN,833
+Israel,IL,ISR,376
+Italy,IT,ITA,380
+Jamaica,JM,JAM,388
+Japan,JP,JPN,392
+Jersey,JE,JEY,832
+Jordan,JO,JOR,400
+Kazakhstan,KZ,KAZ,398
+Kenya,KE,KEN,404
+Kiribati,KI,KIR,296
+"Korea, Democratic People's Republic of",KP,PRK,408
+"Korea, Republic of",KR,KOR,410
+Kosovo,XK,XKX,999
+Kuwait,KW,KWT,414
+Kyrgyzstan,KG,KGZ,417
+Laos,LA,LAO,418
+Latvia,LV,LVA,428
+Lebanon,LB,LBN,422
+Lesotho,LS,LSO,426
+Liberia,LR,LBR,430
+Libya,LY,LBY,434
+Liechtenstein,LI,LIE,438
+Lithuania,LT,LTU,440
+Luxembourg,LU,LUX,442
+Macao,MO,MAC,446
+Madagascar,MG,MDG,450
+Malawi,MW,MWI,454
+Malaysia,MY,MYS,458
+Maldives,MV,MDV,462
+Mali,ML,MLI,466
+Malta,MT,MLT,470
+Marshall Islands,MH,MHL,584
+Martinique,MQ,MTQ,474
+Mauritania,MR,MRT,478
+Mauritius,MU,MUS,480
+Mayotte,YT,MYT,175
+Mexico,MX,MEX,484
+"Micronesia, Federated States of",FM,FSM,583
+Moldova,MD,MDA,498
+Monaco,MC,MCO,492
+Mongolia,MN,MNG,496
+Montenegro,ME,MNE,499
+Montserrat,MS,MSR,500
+Morocco,MA,MAR,504
+Mozambique,MZ,MOZ,508
+Myanmar,MM,MMR,104
+Namibia,NA,NAM,516
+Nauru,NR,NRU,520
+Nepal,NP,NPL,524
+Netherlands,NL,NLD,528
+New Caledonia,NC,NCL,540
+New Zealand,NZ,NZL,554
+Nicaragua,NI,NIC,558
+Niger,NE,NER,562
+Nigeria,NG,NGA,566
+Niue,NU,NIU,570
+Norfolk Island,NF,NFK,574
+North Macedonia,MK,MKD,807
+Northern Mariana Islands,MP,MNP,580
+Norway,NO,NOR,578
+Oman,OM,OMN,512
+Pakistan,PK,PAK,586
+Palau,PW,PLW,585
+Palestine,PS,PSE,275
+Panama,PA,PAN,591
+Papua New Guinea,PG,PNG,598
+Paraguay,PY,PRY,600
+Peru,PE,PER,604
+Philippines,PH,PHL,608
+Pitcairn Islands,PN,PCN,612
+Poland,PL,POL,616
+Portugal,PT,PRT,620
+Puerto Rico,PR,PRI,630
+Qatar,QA,QAT,634
+Reunion,RE,REU,638
+Romania,RO,ROU,642
+Russian Federation,RU,RUS,643
+Rwanda,RW,RWA,646
+Saint Barthelemy,BL,BLM,652
+"Saint Helena, Ascension and Tristan da Cunha",SH,SHN,654
+Saint Kitts and Nevis,KN,KNA,659
+Saint Lucia,LC,LCA,662
+Saint Martin,MF,MAF,663
+Saint Pierre and Miquelon,PM,SPM,666
+Saint Vincent and the Grenadines,VC,VCT,670
+Samoa,WS,WSM,882
+San Marino,SM,SMR,674
+Sao Tome and Principe,ST,STP,678
+Saudi Arabia,SA,SAU,682
+Senegal,SN,SEN,686
+Serbia,RS,SRB,688
+Seychelles,SC,SYC,690
+Sierra Leone,SL,SLE,694
+Singapore,SG,SGP,702
+Sint Maarten,SX,SXM,534
+Slovakia,SK,SVK,703
+Slovenia,SI,SVN,705
+Solomon Islands,SB,SLB,90
+Somalia,SO,SOM,706
+South Africa,ZA,ZAF,710
+South Sudan,SS,SSD,728
+Spain,ES,ESP,724
+Sri Lanka,LK,LKA,144
+Sudan,SD,SDN,729
+Suriname,SR,SUR,740
+Svalbard and Jan Mayen,SJ,SJM,744
+Sweden,SE,SWE,752
+Switzerland,CH,CHE,756
+Syria,SY,SYR,760
+Taiwan,TW,TWN,158
+Tajikistan,TJ,TJK,762
+Tanzania,TZ,TZA,834
+Thailand,TH,THA,764
+Timor-Leste,TL,TLS,626
+Togo,TG,TGO,768
+Tokelau,TK,TKL,772
+Tonga,TO,TON,776
+Trinidad and Tobago,TT,TTO,780
+Tunisia,TN,TUN,788
+Turkey,TR,TUR,792
+Turkmenistan,TM,TKM,795
+Turks and Caicos Islands,TC,TCA,796
+Tuvalu,TV,TUV,798
+U. S. Virgin Islands,VI,VIR,850
+Uganda,UG,UGA,800
+Ukraine,UA,UKR,804
+United Arab Emirates,AE,ARE,784
+United Kingdom,GB,GBR,826
+United States Minor Outlying Islands,UM,UMI,581
+United States of America,US,USA,840
+United States,US,USA,840
+Uruguay,UY,URY,858
+Uzbekistan,UZ,UZB,860
+Vanuatu,VU,VUT,548
+Venezuela,VE,VEN,862
+Vietnam,VN,VNM,704
+Wallis and Futuna,WF,WLF,876
+Western Sahara,EH,ESH,732
+Yemen,YE,YEM,887
+Zambia,ZM,ZMB,894
+Zimbabwe,ZW,ZWE,716

--- a/dojo/indicators/populate_wdi_data.py
+++ b/dojo/indicators/populate_wdi_data.py
@@ -12,12 +12,8 @@ from uuid import uuid4
 from urllib.parse import urlparse
 import boto3
 import pdb
-
-ELASTICSEARCH_URL="http://elasticsearch:9200"
-ELASTICSEARCH_PORT=9200
-es = Elasticsearch([ELASTICSEARCH_URL], port=ELASTICSEARCH_PORT)
-
-s3 = boto3.client("s3")
+import argparse
+import pydantic
 
 def main():
     download_data()
@@ -601,3 +597,18 @@ def save_parquet(df,name, id):
     # send to s3
     s3.put_object(Bucket=location_info.netloc, Key=output_path, Body=fileobj)
 
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--es", help="Elasticsearch connection string")
+    parser.add_argument("--aws_key", help="aws_key")
+    parser.add_argument("--aws_secret", help="aws_secret")
+    args = parser.parse_args()
+
+    ELASTICSEARCH_URL=args.es
+    es = Elasticsearch([ELASTICSEARCH_URL])
+
+    s3 = boto3.client("s3",
+                    aws_access_key_id=args.aws_key,
+                    aws_secret_access_key=args.aws_secret)
+    
+    main()


### PR DESCRIPTION
@marshHawk4 @david-andrew please take a look at this. You can run it with something like:

```
python populate_wdi_data.py --es=http://localhost:9200 --aws_key='ACCESS_KEY' --aws_secret='SECRET'
```
except it doesn't work because `classDTO.StudentsDTO` on line 581 is not defined. Note that `pydantic` itself was not defined either and the `country.csv` file was missing so this would not have worked.

Also note that since we want this to be a utility, making things like the ES instance and AWS creds (as well as the bucket) configurable instead of hard coded is worth the extra 10 minutes of effort. 