### PR TITLE
Fix published model version bump UI bug

### DIFF
--- a/ui/client/components/SummaryIntroDialog.js
+++ b/ui/client/components/SummaryIntroDialog.js
@@ -88,7 +88,9 @@ const SummaryIntroDialog = ({
     setTimeout(() => setStep(defaultStep), theme.transitions.duration.standard);
   };
 
-  const versionBumpModel = async (relaunch) => {
+  const versionBumpModel = async (event, relaunch) => {
+    // prevent the page from redirecting on form submit
+    event.preventDefault();
     // set the endpoint for version bumping
     let versionBumpUrl = `/api/dojo/models/version/${model.id}`;
     let provisionUrl;
@@ -305,11 +307,11 @@ const SummaryIntroDialog = ({
                       disableElevation
                       className={classes.bigButton}
                       data-test="introDialogStartOverBtn"
-                      onClick={() => {
+                      onClick={(event) => {
                         if (model?.image) {
                           setStep('confirm');
                         } else {
-                          versionBumpModel();
+                          versionBumpModel(event);
                         }
                       }}
                     >
@@ -333,7 +335,7 @@ const SummaryIntroDialog = ({
                       color="primary"
                       disableElevation
                       className={classes.bigButton}
-                      onClick={() => versionBumpModel(true)}
+                      onClick={(event) => versionBumpModel(event, true)}
                       disabled={!model?.image}
                     >
                       <Grid container direction="row" justifyContent="center" alignItems="center">
@@ -398,7 +400,7 @@ const SummaryIntroDialog = ({
                     type="submit"
                     disableElevation
                     disabled={disableConfirm}
-                    onClick={() => versionBumpModel()}
+                    onClick={(event) => versionBumpModel(event)}
                     data-test="introDialogConfirmNameBtn"
                   >
                     Confirm


### PR DESCRIPTION
When trying to go through the model summary page version bump flow for a previously published model, there was a bug where the page would redirect/reload to the summary page URL for the old (published) model ID in the middle of the flow. This fixes that bug by preventing the form default behavior when the submit button ('Confirm') is clicked. 