### PR TITLE
Two model summary page bugfixes

### DIFF
--- a/ui/client/components/SummaryIntroDialog.js
+++ b/ui/client/components/SummaryIntroDialog.js
@@ -19,7 +19,7 @@ import Slide from '@material-ui/core/Slide';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 
-import { makeStyles, useTheme } from '@material-ui/core/styles';
+import { makeStyles, useTheme, withStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
   versionButtonWrapper: {
@@ -43,22 +43,26 @@ const useStyles = makeStyles((theme) => ({
     textTransform: 'none',
   },
   pageLoadDialog: {
-    minHeight: '360px',
-    minWidth: '600px',
+    height: 'fit-content',
+    width: 'fit-content',
   },
   slideWrapper: {
     // there's a bug in the MUI slide component that causes it to overflow in certain directions
     // https://github.com/mui-org/material-ui/issues/13701
-    overflow: 'hidden',
-  },
-  confirmContent: {
-    overflowY: 'hidden',
+    overflowX: 'hidden',
   },
   confirmInput: {
     width: '100%',
     marginTop: theme.spacing(1),
   },
 }));
+
+// This prevents an ugly interior (second) scrollbar from appearing on smaller screens
+const DialogContentNoOverflow = withStyles({
+  root: {
+    overflow: 'hidden',
+  }
+})(DialogContent);
 
 const SummaryIntroDialog = ({
   open, setOpen, model, summaryLoading, setSummaryLoading
@@ -164,7 +168,7 @@ const SummaryIntroDialog = ({
             <DialogTitle align="center">
               Would you like to create a new model version?
             </DialogTitle>
-            <DialogContent>
+            <DialogContentNoOverflow>
               <DialogContentText component="div">
                 <Typography gutterBottom>
                   Any edits to the existing model&apos;s details, annotations,
@@ -207,7 +211,7 @@ const SummaryIntroDialog = ({
                   Create new version
                 </Button>
               </DialogActions>
-            </DialogContent>
+            </DialogContentNoOverflow>
           </div>
         );
       case 'continue':
@@ -216,7 +220,7 @@ const SummaryIntroDialog = ({
             <DialogTitle align="center">
               Would you like to edit your model?
             </DialogTitle>
-            <DialogContent>
+            <DialogContentNoOverflow>
               <DialogContentText component="div">
                 <Typography gutterBottom>
                   You will be able to launch the terminal and make changes where you left off
@@ -259,7 +263,7 @@ const SummaryIntroDialog = ({
                   Edit model
                 </Button>
               </DialogActions>
-            </DialogContent>
+            </DialogContentNoOverflow>
           </div>
         );
       case 'container':
@@ -270,7 +274,7 @@ const SummaryIntroDialog = ({
                 <DialogTitle align="center">
                   How would you like to run your model?
                 </DialogTitle>
-                <DialogContent>
+                <DialogContentNoOverflow>
                   <DialogContentText component="div">
                     <Typography gutterBottom>
                       Choose whether to:
@@ -349,18 +353,18 @@ const SummaryIntroDialog = ({
                       </Grid>
                     </Button>
                   </DialogActions>
-                </DialogContent>
+                </DialogContentNoOverflow>
               </div>
             </Slide>
           </span>
         );
       case 'confirm':
         return (
-          <>
+          <div>
             <DialogTitle align="center">
               Are you sure you want to start over from a base image?
             </DialogTitle>
-            <DialogContent classes={{ root: classes.confirmContent }}>
+            <DialogContentNoOverflow>
               <DialogContentText component="div">
                 <Typography>
                   Starting over from a base image will remove your existing output, accessory,
@@ -405,16 +409,16 @@ const SummaryIntroDialog = ({
                   </Button>
                 </DialogActions>
               </form>
-            </DialogContent>
-          </>
+            </DialogContentNoOverflow>
+          </div>
         );
       default:
         return (
           <>
             <DialogTitle align="center">There was an error</DialogTitle>
-            <DialogContent>
+            <DialogContentNoOverflow>
               <DialogContentText>Please reload the page</DialogContentText>
-            </DialogContent>
+            </DialogContentNoOverflow>
           </>
         );
     }

--- a/ui/client/summary.js
+++ b/ui/client/summary.js
@@ -54,19 +54,16 @@ const Summary = () => {
         });
     }
 
-    // save an empty variable so we can clear the timeout later on
-    let clearLock;
-    if (terminal === 'true' && !lock) {
-      // if we arrive with the terminal param but no lock
-      // set a timeout to get rid of it in 30 seconds (enough time to fetch a lock)
-      clearLock = setTimeout(() => history.replace(`/summary/${modelId}`), 30000);
-    }
+    const timeout = setTimeout(() => {
+      // if we do have the terminal param set but we haven't yet loaded a lock
+      // after the timeout has finished, then get rid of the terminal param
+      if (terminal === 'true' && !lock) {
+        history.replace(`/summary/${modelId}`);
+      }
+    }, 10000);
 
-    if (terminal === 'true' && lock) {
-      // if we fetch a lock in the meantime, clear the timeout
-      // if there was never a timeout, calling this will do nothing
-      clearTimeout(clearLock);
-    }
+    // clear the timeout when we cleanup the useEffect
+    return () => clearTimeout(timeout);
   }, [modelId, terminal, history, lock]);
 
   // if the model is loading or returns an error, don't show the page yet

--- a/ui/client/summary.js
+++ b/ui/client/summary.js
@@ -53,9 +53,19 @@ const Summary = () => {
           console.log('Container auto-shutdown sequence initiated');
         });
     }
-    // if we arrive with the terminal param but no lock, get rid of the terminal param
+
+    // save an empty variable so we can clear the timeout later on
+    let clearLock;
     if (terminal === 'true' && !lock) {
-      history.replace(`/summary/${modelId}`);
+      // if we arrive with the terminal param but no lock
+      // set a timeout to get rid of it in 30 seconds (enough time to fetch a lock)
+      clearLock = setTimeout(() => history.replace(`/summary/${modelId}`), 30000);
+    }
+
+    if (terminal === 'true' && lock) {
+      // if we fetch a lock in the meantime, clear the timeout
+      // if there was never a timeout, calling this will do nothing
+      clearTimeout(clearLock);
     }
   }, [modelId, terminal, history, lock]);
 


### PR DESCRIPTION
This PR fixes two small model summary page bugs that I came across while working on Keycloak auth. 

1. The `?terminal=true` url param that we use to keep a user connected to the terminal UI (show them the back button, allow them to edit things on the summary page) was getting erroneously wiped clear because we were checking for the existence of the `lock` before it was getting loaded in. We're now waiting 10 seconds for the lock to load before clearing the terminal param and getting them off the 'running' summary page.
2. The model summary intro/version bump dialog was hiding any overflow due to a visual flicker MUI bug. Unfortunately this meant that on smaller screens (such as when developing with a console open) the buttons are totally hidden, with no way to click to the next dialog step. This is now fixed and the correct scroll is enabled, with the MUI bug still handled. 