### PR TITLE
Disable dataset column snapback

### DIFF
--- a/ui/client/datasets/annotations/ColumnPanel.js
+++ b/ui/client/datasets/annotations/ColumnPanel.js
@@ -252,7 +252,6 @@ export default withStyles(({ palette, spacing, breakpoints }) => ({
   onSubmit, onClose, columnStats,
   fieldsConfig=()=>({})
 }) => {
-
   const [displayStatistics, setDisplayStatistics] = React.useState(false);
 
   function clearColumnAnnotations() {
@@ -428,7 +427,7 @@ export default withStyles(({ palette, spacing, breakpoints }) => ({
                     annotateColumns(newAnnotations);
 
                     onClose();
-                    onSubmit();
+                    onSubmit(columnName);
                   }}
                 >
                   {(formik) => (

--- a/ui/client/datasets/annotations/Table/index.js
+++ b/ui/client/datasets/annotations/Table/index.js
@@ -11,6 +11,8 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import Tooltip from '@material-ui/core/Tooltip';
 
+import BasicAlert from '../../../components/BasicAlert';
+
 import ColumnPanel from '../ColumnPanel';
 
 import { calcPointerLocation, groupColumns } from './helpers';
@@ -117,7 +119,11 @@ export default withStyles(({ palette }) => ({
   const [pageSize, setPageSize] = useState(rowsPerPageOptions[0]);
   const [highlightedColumn, setHighlightedColumn] = useState(null);
   const [editingColumn, setEditingColumn] = useState(null);
-  const [anchorPosition, setAnchorPosition] = useState('right');
+  const [annotationSuccessAlert, setAnnotationSuccessAlert] = useState();
+  const [annotationAlertMessage, setAnnotationAlertMessage] = useState({
+    message: '',
+    severity: 'success',
+  });
 
   const [isShowMarkers, setShowMarkers] = useState(true);
 
@@ -132,18 +138,11 @@ export default withStyles(({ palette }) => ({
   );
 
   const handleCellClick = (cell) => {
-
     const isColumnAnnotated = !isEmpty(annotations[cell.field]);
 
     if (!isColumnAnnotated && !addingAnnotationsAllowed) {
       return;
     }
-
-    // NOTE removed opening panel on different screen areas
-    //      due to UX + having a statistics tab always on left side.
-    //      We can add/revisit if we'd like. Else remove all this comment if
-    //      it ages badly.
-    // setAnchorPosition(calcPointerLocation(event));
 
     const multiPartMember = find(
       multiPartData, (item) => item && item.members.includes(cell.field)
@@ -236,12 +235,11 @@ export default withStyles(({ palette }) => ({
 
   const gridRef = useRef(null);
 
-  function onAnnotationSave() {
-    const grid = gridRef.current;
-    // Scroll internal Table window to left when saving an annotation.
-    // Only useful when creating a new annotation (not editing). We can enhance further.
-    const scrollWindow = grid.querySelector('.MuiDataGrid-window');
-    scrollWindow.scrollTo(0, scrollWindow.scrollTop);
+  function onAnnotationSave(columnName) {
+    setAnnotationSuccessAlert(true);
+    setAnnotationAlertMessage({
+      message: `Your annotation of ${columnName} was successfully added`, severity: 'success'
+    });
   }
 
   return (
@@ -252,16 +250,16 @@ export default withStyles(({ palette }) => ({
           classes={{ tooltip: classes.tooltip }}
           title="Display context icons for columns with inferred data, annotated as primary, or as qualifier."
         >
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={isShowMarkers}
-              onChange={e => setShowMarkers(e.target.checked)}
-              color="primary"
-            />
-          }
-          label="Show Additional Markers"
-        />
+          <FormControlLabel
+            control={(
+              <Checkbox
+                checked={isShowMarkers}
+                onChange={(e) => setShowMarkers(e.target.checked)}
+                color="primary"
+              />
+            )}
+            label="Show Additional Markers"
+          />
         </Tooltip>
       </div>
 
@@ -294,7 +292,6 @@ export default withStyles(({ palette }) => ({
       />
 
       <ColumnPanel
-        anchorPosition={anchorPosition}
         onClose={toggleDrawer}
         onSubmit={onAnnotationSave}
 
@@ -313,7 +310,12 @@ export default withStyles(({ palette }) => ({
 
         fieldsConfig={fieldsConfig}
       />
-
+      <BasicAlert
+        alert={annotationAlertMessage}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        visible={annotationSuccessAlert}
+        setVisible={setAnnotationSuccessAlert}
+      />
     </div>
   );
 });


### PR DESCRIPTION
After annotating a dataset column, the datagrid was automatically horizontally scrolling back to the start of the columns. This PR replaces the 'snapback' behavior with a success alert and leaves the user horizontally scrolled to the same position. 