### PR TITLE
Mouseless Dataset table navigation

### DIFF
--- a/ui/client/datasets/annotations/ColumnAnnotation.js
+++ b/ui/client/datasets/annotations/ColumnAnnotation.js
@@ -306,9 +306,9 @@ export const ColumnAnnotation = withStyles((theme) => ({
 }))(({
   classes, editingColumnName, columns,
   values, setFieldValue, validateDateFormat,
-  annotatedColumns, fieldsConfig=()=>({})
+  annotatedColumns, fieldsConfig = () => ({}),
+  focusRef
 }) => {
-
   const displayNamePlaceholder = editingColumnName.includes('+') ? '' : editingColumnName;
   const setQualifiesValues = useCallback(
     (val) => {
@@ -327,6 +327,7 @@ export const ColumnAnnotation = withStyles((theme) => ({
         name="display_name"
         label="Display Name"
         placeholder={displayNamePlaceholder}
+        inputRef={focusRef}
         {...fieldsConfig('display_name')}
       />
 

--- a/ui/client/datasets/annotations/ColumnPanel.js
+++ b/ui/client/datasets/annotations/ColumnPanel.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import clsx from 'clsx';
 import { Form, Formik } from 'formik';
 import * as yup from 'yup';
@@ -252,8 +252,18 @@ export default withStyles(({ palette, spacing, breakpoints }) => ({
   onSubmit, onClose, columnStats,
   fieldsConfig = () => ({})
 }) => {
-
   const [displayStatistics, setDisplayStatistics] = React.useState(false);
+  // focusRef is passed down to columnAnnotation to autofocus on the first input
+  // which we have to do manually due to the potential focus on grid cells (MUI autofocus fails)
+  const focusRef = useRef(null);
+
+  useEffect(() => {
+    if (focusRef.current) {
+      // setTimeout is necessary here to bump this back in the render cycle
+      // to after the drawer is on the page (this seems to be the issue, at least)
+      setTimeout(() => focusRef.current.focus());
+    }
+  }, [columnName]);
 
   useEffect(() => {
     const onEscape = (event) => {
@@ -453,8 +463,9 @@ export default withStyles(({ palette, spacing, breakpoints }) => ({
                           variant="body2"
                           paragraph
                           component="div"
-                          style={{display: 'flex', alignItems: 'center'}}>
-                          <InfoRoundedIcon style={{marginRight: '0.5rem', color: '#51abf1b3'}} />
+                          style={{ display: 'flex', alignItems: 'center' }}
+                        >
+                          <InfoRoundedIcon style={{ marginRight: '0.5rem', color: '#51abf1b3' }} />
                           Defaults include inferred values from Dojo analysis.
                         </Typography>
                       )}
@@ -467,6 +478,7 @@ export default withStyles(({ palette, spacing, breakpoints }) => ({
                         validateDateFormat={validateDateFormat}
                         annotatedColumns={allAnnotatedColumns}
                         fieldsConfig={fieldsConfig}
+                        focusRef={focusRef}
                       />
 
                       <div className={classes.buttonContainer}>

--- a/ui/client/datasets/annotations/ColumnPanel.js
+++ b/ui/client/datasets/annotations/ColumnPanel.js
@@ -272,12 +272,15 @@ export default withStyles(({ palette, spacing, breakpoints }) => ({
       }
     };
 
-    document.addEventListener('keydown', onEscape);
+    // only add the event listener if we have the drawer open
+    if (columnName) {
+      document.addEventListener('keydown', onEscape);
+    }
 
     return () => {
       document.removeEventListener('keydown', onEscape);
     };
-  }, [onClose]);
+  }, [onClose, columnName]);
 
   function clearColumnAnnotations() {
     const multiPart = get(multiPartData, columnName);

--- a/ui/client/datasets/annotations/ColumnPanel.js
+++ b/ui/client/datasets/annotations/ColumnPanel.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import clsx from 'clsx';
 import { Form, Formik } from 'formik';
 import * as yup from 'yup';
@@ -250,10 +250,24 @@ export default withStyles(({ palette, spacing, breakpoints }) => ({
   multiPartData, setMultiPartData,
   validateDateFormat,
   onSubmit, onClose, columnStats,
-  fieldsConfig=()=>({})
+  fieldsConfig = () => ({})
 }) => {
 
   const [displayStatistics, setDisplayStatistics] = React.useState(false);
+
+  useEffect(() => {
+    const onEscape = (event) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', onEscape);
+
+    return () => {
+      document.removeEventListener('keydown', onEscape);
+    };
+  }, [onClose]);
 
   function clearColumnAnnotations() {
     const multiPart = get(multiPartData, columnName);
@@ -295,25 +309,25 @@ export default withStyles(({ palette, spacing, breakpoints }) => ({
 
   const statDataAvailable = !isEmpty(statistics) || !isEmpty(histogramData.labels);
 
-  const allAnnotatedColumns = columns.filter(column => annotations[column.field]);
+  const allAnnotatedColumns = columns.filter((column) => annotations[column.field]);
 
   return (
     <Drawer
       variant="persistent"
-      classes={{ paper: clsx({[classes.root]: true, [classes.expanded]: displayStatistics }) }}
+      classes={{ paper: clsx({ [classes.root]: true, [classes.expanded]: displayStatistics }) }}
       anchor={anchorPosition}
       open={Boolean(columnName)}
       onClose={onClose}
     >
       {columnName && (
-        <div style={{height: '200%', display: 'flex'}}>
+        <div style={{ height: '200%', display: 'flex' }}>
 
           <div className={classes.tabsPanel}>
             <div>
               <Button
                 fullWidth
                 disableRipple
-                classes={{root: classes.statisticsButton}}
+                classes={{ root: classes.statisticsButton }}
                 onClick={() => setDisplayStatistics(!displayStatistics)}
                 disabled={!statDataAvailable}
                 color="primary"
@@ -472,6 +486,7 @@ export default withStyles(({ palette, spacing, breakpoints }) => ({
                           <Button
                             color="primary"
                             onClick={formik.handleSubmit}
+                            type="submit"
                           >
                             Save
                           </Button>

--- a/ui/client/datasets/annotations/Table/Header.js
+++ b/ui/client/datasets/annotations/Table/Header.js
@@ -82,6 +82,18 @@ const useStyles = makeStyles((theme) => ({
     position: 'absolute',
     height: '14px',
     top: '33px',
+  },
+  highlightedButton: {
+    backgroundColor: theme.palette.grey[100],
+    animation: '$pulse 1.5s infinite alternate',
+  },
+  '@keyframes pulse': {
+    from: {
+      outline: `1px solid ${theme.palette.primary.light}`,
+    },
+    to: {
+      outline: '1px solid white',
+    }
   }
 }));
 
@@ -132,7 +144,8 @@ const Header = ({
   showMarkers,
   addingAnnotationsAllowed,
   column,
-  buttonClick
+  buttonClick,
+  drawerOpen = false,
 }) => {
   const classes = useStyles();
   const isAnnotated = ['annotated', 'primary'].includes(status);
@@ -181,6 +194,10 @@ const Header = ({
             style={{ visibility: isMultiPartMember ? 'hidden' : 'visible' }}
             size="small"
             onClick={() => buttonClick(column)}
+            className={
+              isHighlighted && !isAnnotated && !drawerOpen
+                ? classes.highlightedButton : null
+            }
           >
             {isAnnotated ? 'Edit' : 'Annotate'}
           </Button>

--- a/ui/client/datasets/annotations/Table/Header.js
+++ b/ui/client/datasets/annotations/Table/Header.js
@@ -65,7 +65,6 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: 'bold'
   },
   headerWrapper: {
-    cursor: 'pointer',
     width: '100%',
   },
   headerText: {
@@ -87,7 +86,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const MultiPartHeader = ({
-  status, colSpan, TypeIcon, qualifies, showMarkers
+  status, colSpan, TypeIcon, qualifies, showMarkers, buttonClick, column
 }) => {
   const classes = useStyles();
   const shouldDisplayStatus = ((['inferred', 'primary'].includes(status) || qualifies));
@@ -109,6 +108,7 @@ const MultiPartHeader = ({
         <Button
           variant="outlined"
           size="small"
+          onClick={() => buttonClick(column)}
         >
           Edit
         </Button>
@@ -130,7 +130,9 @@ const Header = ({
   category, // type
   qualifies,
   showMarkers,
-  addingAnnotationsAllowed
+  addingAnnotationsAllowed,
+  column,
+  buttonClick
 }) => {
   const classes = useStyles();
   const isAnnotated = ['annotated', 'primary'].includes(status);
@@ -162,6 +164,8 @@ const Header = ({
           qualifies={qualifies}
           TypeIcon={TypeIcon}
           showMarkers={showMarkers}
+          column={column}
+          buttonClick={buttonClick}
         />
       )}
 
@@ -176,6 +180,7 @@ const Header = ({
             disabled={isMultiPartMember}
             style={{ visibility: isMultiPartMember ? 'hidden' : 'visible' }}
             size="small"
+            onClick={() => buttonClick(column)}
           >
             {isAnnotated ? 'Edit' : 'Annotate'}
           </Button>

--- a/ui/client/datasets/annotations/Table/Header.js
+++ b/ui/client/datasets/annotations/Table/Header.js
@@ -194,6 +194,7 @@ const Header = ({
             style={{ visibility: isMultiPartMember ? 'hidden' : 'visible' }}
             size="small"
             onClick={() => buttonClick(column)}
+            /* Disable the pulse animation when the drawer is open or once it's annotated */
             className={
               isHighlighted && !isAnnotated && !drawerOpen
                 ? classes.highlightedButton : null

--- a/ui/client/datasets/annotations/Table/index.js
+++ b/ui/client/datasets/annotations/Table/index.js
@@ -252,6 +252,11 @@ export default withStyles(({ palette }) => ({
   };
 
   const handleCellKeyDown = (cell, event) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      // DataGrid's vertical scroll is only disabled with both stopPropagation and preventDefault
+      event.stopPropagation();
+      event.preventDefault();
+    }
     if (event.key === 'Enter') {
       handleCellClick(cell);
     }

--- a/ui/client/datasets/annotations/Table/index.js
+++ b/ui/client/datasets/annotations/Table/index.js
@@ -30,10 +30,10 @@ const Cell = withStyles(({ palette, spacing }) => ({
     marginRight: -6,
     // NOTE How much to space cell content left. We can also use flex + center items
     paddingLeft: spacing(2),
+    cursor: 'pointer',
   },
   hoveredCell: {
     backgroundColor: palette.grey[100],
-    cursor: 'pointer',
   },
 }))(({
   isHighlighted, classes, value
@@ -245,10 +245,16 @@ export default withStyles(({ palette }) => ({
   }
 
   const highlightColumn = (cell, event) => {
-    const nextField = event.relatedTarget?.getAttribute('data-field');
-    if (nextField) {
-      setHighlightedColumn(nextField);
+    // Get the next column to highlight from relatedTarget - this works for arrow key navigation
+    const clicked = event.relatedTarget;
+    if (clicked?.getAttribute('role') !== 'cell') {
+      // only continue if the user has clicked on a 'cell'
+      return;
     }
+
+    const nextHighlight = clicked.getAttribute('data-field');
+
+    if (nextHighlight) setHighlightedColumn(nextHighlight);
   };
 
   const handleCellKeyDown = (cell, event) => {

--- a/ui/client/datasets/annotations/Table/index.js
+++ b/ui/client/datasets/annotations/Table/index.js
@@ -140,7 +140,7 @@ export default withStyles(({ palette }) => ({
     find(multiPartData, (mp) => mp.members.includes(columnFieldName))
   );
 
-  const handleCellClick = (cell) => {
+  const openAnnotationPanel = (cell) => {
     const isColumnAnnotated = !isEmpty(annotations[cell.field]);
     if (!isColumnAnnotated && !addingAnnotationsAllowed) {
       return;
@@ -221,7 +221,7 @@ export default withStyles(({ palette }) => ({
           {...calcColumnAttrs(colDef.field)}
           heading={colDef.headerName}
           column={column}
-          buttonClick={handleCellClick}
+          buttonClick={openAnnotationPanel}
           isHighlighted={(colDef.field === highlightedColumn)}
           drawerOpen={Boolean(editingColumn)}
         />
@@ -252,8 +252,10 @@ export default withStyles(({ palette }) => ({
       return;
     }
 
+    // Fetch the column name out of the element's data-field attribute
     const nextHighlight = clicked.getAttribute('data-field');
 
+    // and set our state to the column name, if it existed
     if (nextHighlight) setHighlightedColumn(nextHighlight);
   };
 
@@ -264,7 +266,7 @@ export default withStyles(({ palette }) => ({
       event.preventDefault();
     }
     if (event.key === 'Enter') {
-      handleCellClick(cell);
+      openAnnotationPanel(cell);
     }
   };
 
@@ -310,8 +312,8 @@ export default withStyles(({ palette }) => ({
         headerHeight={HEADER_HEIGHT}
         rowsPerPageOptions={rowsPerPageOptions}
         rows={rows}
-        onCellDoubleClick={handleCellClick}
-        onColumnHeaderDoubleClick={handleCellClick}
+        onCellDoubleClick={openAnnotationPanel}
+        onColumnHeaderDoubleClick={openAnnotationPanel}
         GridSortModel={null}
         onCellKeyDown={handleCellKeyDown}
         onCellBlur={highlightColumn}


### PR DESCRIPTION
This PR makes a number of small UI tweaks to the Dataset registration table view to allow for keyboard navigation. 
The changes are as follows:
- Click into any column to navigate between columns with arrow keys
- Get rid of single cell highlighting 
- Enter/return opens annotation panel
- Escape closes annotation panel
- Annotation panel opens with first input autofocused

There are also assorted visual tweaks along with this to make it all look better. 