### PR TITLE
Adds LineController to Temporal Coverage Data Transformation Chart

### DIFF
--- a/ui/client/datasets/ClipTime.js
+++ b/ui/client/datasets/ClipTime.js
@@ -27,6 +27,7 @@ import {
   PointElement,
   TimeScale,
   LineElement,
+  LineController,
 } from 'chart.js';
 import {
   Chart
@@ -42,6 +43,7 @@ ChartJS.register(
   Tooltip,
   PointElement,
   LineElement,
+  LineController,
 );
 
 const options = {


### PR DESCRIPTION
I missed importing and registering the LineController, which is required for a ChartJS Line chart. This should fix the `"Line" is not a registered controller` error getting thrown when the Select Temporal Coverage drawer is opened. 

I'm not sure why this is only happening on the deployed instance - perhaps ChartJS is importing everything when in dev, and then only doing the tree shaking selective import when it's bundled up for deployment? 

I left in a couple unnecessary imports (the Bar imports) because I don't want to potentially break anything. I'll remove those in a future commit. 