### PR TITLE
Prevent smaller than current temporal resolution selection

### DIFF
--- a/ui/client/datasets/AdjustTemporalResolution.js
+++ b/ui/client/datasets/AdjustTemporalResolution.js
@@ -74,6 +74,15 @@ export default withStyles((theme) => ({
   const [selectedResolution, setSelectedResolution] = useState(savedResolution || '');
   const [selectedAggregation, setSelectedAggregation] = useState(savedAggregation || '');
 
+  // TODO: remove this once we get a list from the backend
+  // this is to remove all options below the current time bucket
+  let firstOption;
+  if (resolutionOptions && oldResolution?.unit) {
+    firstOption = resolutionOptions.findIndex((opt) => (
+      opt.description.includes(oldResolution.unit)
+    ));
+  }
+
   const handleSaveClick = () => {
     if (selectedResolution !== '' && selectedAggregation !== '') {
       setSavedResolution(selectedResolution);
@@ -148,7 +157,7 @@ export default withStyles((theme) => ({
               onChange={handleChangeResolution}
               label="Resolution"
             >
-              {resolutionOptions.map((option) => (
+              {resolutionOptions.slice(firstOption).map((option) => (
                 <MenuItem key={option.description} value={option}>
                   {option.description}
                 </MenuItem>


### PR DESCRIPTION
This commit didn't make it into the main Data Transformation PR. It's a small fix to prevent users from selecting temporal resolutions smaller than their current resolution. Eventually we'll get the exact list of values to show from the backend, but for now we're cropping the list here. 