### PR TITLE
Env var disable semantic highlighting on UI

### DIFF
--- a/envfile.sample
+++ b/envfile.sample
@@ -40,3 +40,4 @@ UVICORN_RELOAD=True
 #DATASET_STORAGE_BASE_URL=s3://jataware-world-modelers-dev/datasets/
 #DOCUMENT_STORAGE_BASE_URL=s3://jataware-world-modelers-dev/documents/
 DOCUMENT_STORAGE_BASE_URL=file:///documents/
+DISABLE_SEMANTIC_HIGHLIGHT=

--- a/envfile.sample
+++ b/envfile.sample
@@ -40,4 +40,4 @@ UVICORN_RELOAD=True
 #DATASET_STORAGE_BASE_URL=s3://jataware-world-modelers-dev/datasets/
 #DOCUMENT_STORAGE_BASE_URL=s3://jataware-world-modelers-dev/documents/
 DOCUMENT_STORAGE_BASE_URL=file:///documents/
-DISABLE_SEMANTIC_HIGHLIGHT=
+DISABLE_SEMANTIC_HIGHLIGHT=false

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -452,7 +452,7 @@ const ViewDocumentsGrid = withStyles((theme) => ({
         Promise.all(allDocPromises).then(() => {
           setDocParagraphResults(allParagraphs);
 
-          if (!process.env.DISABLE_SEMANTIC_HIGHLIGHT) {
+          if (process.env.DISABLE_SEMANTIC_HIGHLIGHT !== "true") {
             // fetch all highlights for results
             const matches = map(allParagraphs, 'text');
             const query = searchTerm;

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -452,21 +452,23 @@ const ViewDocumentsGrid = withStyles((theme) => ({
         Promise.all(allDocPromises).then(() => {
           setDocParagraphResults(allParagraphs);
 
-          // fetch all highlights for results
-          const matches = map(allParagraphs, 'text');
-          const query = searchTerm;
+          if (!process.env.DISABLE_SEMANTIC_HIGHLIGHT) {
+            // fetch all highlights for results
+            const matches = map(allParagraphs, 'text');
+            const query = searchTerm;
 
-          let url = `/api/dojo/paragraphs/highlight`;
+            let url = `/api/dojo/paragraphs/highlight`;
 
-          return axios.post(url, {
-            query,
-            matches
-          })
-            .then((response) => {
-              setHighlights(response.data.highlights)
+            return axios.post(url, {
+              query,
+              matches
+            }).then((response) => {
+              setHighlights(response.data.highlights);
               return;
-            })
-
+            });
+          } else {
+            console.info("Semantic Highlighter disabled.");
+          }
         });
 
       })


### PR DESCRIPTION
Added DISABLE_SEMANTIC_HIGHLIGHT to .envfile (sample). The UI will disable API semantic highlight call, on Document explorer/search page, if it's value is `"true"`.

The UI fallbacks to keyword search calculated in the browser/js itself.