### PR TITLE
Fix model table overflow

### DIFF
--- a/ui/client/components/ViewModels.js
+++ b/ui/client/components/ViewModels.js
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
   },
   gridContainer: {
     height: '400px',
-    width: '1800px',
+    maxWidth: '1800px',
     margin: '0 auto',
   },
   header: {
@@ -247,7 +247,7 @@ const ViewModels = ({
           },
         )
       ),
-      width: 170,
+      width: 165,
     },
     {
       field: 'description',
@@ -256,12 +256,6 @@ const ViewModels = ({
       width: 280,
     },
     { field: 'id', headerName: 'ID', width: 300 },
-    {
-      field: 'commit_message',
-      headerName: 'Commit Message',
-      renderCell: expandableCell,
-      width: 270,
-    },
     lastRunStatus,
     {
       field: 'is_published',

--- a/ui/client/components/ViewModels.js
+++ b/ui/client/components/ViewModels.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 
 import axios from 'axios';
 
-
 import AutorenewIcon from '@material-ui/icons/Autorenew';
 import Button from '@material-ui/core/Button';
 import CheckOutlinedIcon from '@material-ui/icons/CheckOutlined';
@@ -11,12 +10,12 @@ import Container from '@material-ui/core/Container';
 import { DataGrid } from '@material-ui/data-grid';
 import ErrorOutlineOutlinedIcon from '@material-ui/icons/ErrorOutlineOutlined';
 import HelpIcon from '@material-ui/icons/Help';
-import { Link } from 'react-router-dom';
 import Typography from '@material-ui/core/Typography';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 
 import { makeStyles } from '@material-ui/core/styles';
 
-import { useHistory } from 'react-router-dom';
+import { useHistory, Link } from 'react-router-dom';
 
 import ExpandableDataGridCell from './ExpandableDataGridCell';
 import LoadingOverlay from './LoadingOverlay';
@@ -65,6 +64,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
+    flexWrap: 'wrap',
   },
 }));
 
@@ -161,6 +161,8 @@ const ViewModels = ({
   const [displayUnpublished, setDisplayUnpublished] = useState(true);
 
   const [searchedModels, setSearchedModels] = useState(null);
+  // if on a large screen, we want certain column widths set
+  const largeScreen = useMediaQuery('(min-width:1250px)');
 
   useEffect(() => {
     fetchModels(includeStatuses, setModels, setModelsLoading, setModelsError);
@@ -209,7 +211,8 @@ const ViewModels = ({
   const lastRunStatus = !includeStatuses ? {} : {
     field: 'last_run_status',
     headerName: 'Status',
-    width: 120,
+    disableColumnMenu: true,
+    width: 100,
     renderCell: ({ value }) => (
       <div className={classes.published}>
         {value === 'success' ? <CheckOutlinedIcon className={classes.check} />
@@ -225,17 +228,17 @@ const ViewModels = ({
       field: 'name',
       headerName: 'Name',
       renderCell: expandableCell,
-      width: 150,
+      width: largeScreen ? 140 : 120,
     },
     {
       field: 'family_name',
       headerName: 'Family Name',
       renderCell: expandableCell,
-      width: 170,
+      width: largeScreen ? 170 : 130,
     },
     {
       field: 'created_at',
-      headerName: 'Last Updated',
+      headerName: 'Updated',
       valueFormatter: (params) => (
         new Date(params.value).toLocaleDateString(
           'en-US',
@@ -247,20 +250,29 @@ const ViewModels = ({
           },
         )
       ),
-      width: 165,
+      width: 130,
     },
     {
       field: 'description',
       headerName: 'Description',
       renderCell: expandableCell,
-      width: 280,
+      sortable: false,
+      // use flexible sizing so description will fill the space for > 1250
+      flex: largeScreen ? 1 : 0,
+      width: 200,
     },
-    { field: 'id', headerName: 'ID', width: 300 },
+    {
+      field: 'id',
+      headerName: 'ID',
+      renderCell: expandableCell,
+      width: 300,
+    },
     lastRunStatus,
     {
       field: 'is_published',
       headerName: 'Published',
-      width: 140,
+      disableColumnMenu: true,
+      width: 120,
       renderCell: ({ value }) => (
         <div className={classes.published}>
           {value === true && <CloudDoneOutlinedIcon className={classes.check} />}


### PR DESCRIPTION
This fixes the unnecessary View Models table screen overflowing and removes the Commit Message column.
 
The description column is now flexible width at larger screen sizes, so we no longer have the large blank column past the View Models button. It then takes on a fixed width at smaller screen sizes so we don't lose the title in the header (an annoying feature of this version of Datagrid). A few other columns have reduced widths at smaller sizes. Screenshots attached below. Below a certain size, the table will still overflow, but now the scrollbar appears within the table's container and not mess up the layout of the whole page/push the buttons above the table off the screen. 

![Screenshot 2023-03-21 at 11 25 19 AM](https://user-images.githubusercontent.com/2448578/226656916-e8de72d2-f91b-4ae9-a616-0a69c255434c.png)
<img width="757" alt="Screenshot 2023-03-21 at 11 25 27 AM" src="https://user-images.githubusercontent.com/2448578/226656923-916e79f8-1b61-4775-8188-b4b911ac8c3a.png">
<img width="627" alt="Screenshot 2023-03-21 at 11 25 42 AM" src="https://user-images.githubusercontent.com/2448578/226656926-2c88b1ba-13ca-4cea-81b2-2825835157ff.png">
<img width="511" alt="Screenshot 2023-03-21 at 11 26 00 AM" src="https://user-images.githubusercontent.com/2448578/226656928-78e35e9c-3ac6-4acd-a83d-da159dd55d7d.png">



