### PR TITLE
Dataset Column Annotation Display Name Default

### DIFF
--- a/ui/client/datasets/annotations/ColumnPanel.js
+++ b/ui/client/datasets/annotations/ColumnPanel.js
@@ -448,6 +448,8 @@ export default withStyles(({ palette, spacing, breakpoints }) => ({
                       ...individualPartsOverrides,
                       [targetColumnName]: {
                         ...cleanValues,
+                        display_name: cleanValues.display_name
+                          ? cleanValues.display_name : columnName,
                         annotated: true
                       }
                     };


### PR DESCRIPTION
This PR sets an annotation's display name to the column name if no display name is chosen. The display name field will just show the placeholder (the column name) until the user saves the annotation. If they then reopen the annotated column's drawer, they'll see the column name as the Display Name text field value. 