### PR TITLE
Fix in order to download CSV from parquet files that use http|https d…

### DIFF
--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -196,16 +196,19 @@ def list_files(path):
 
 
 async def stream_csv_from_data_paths(data_paths, wide_format="false"):
+
+    storage_options = {
+        "key": os.getenv("AWS_ACCESS_KEY_ID"),
+        "secret": os.getenv("AWS_SECRET_ACCESS_KEY"),
+        "token": None,
+        "client_kwargs": {"endpoint_url": None},
+    }
+
     # Build single dataframe
     df = pd.concat(
         pd.read_parquet(
             file,
-            storage_options={
-                "key": os.getenv("AWS_ACCESS_KEY_ID"),
-                "secret": os.getenv("AWS_SECRET_ACCESS_KEY"),
-                "token": None,
-                "client_kwargs": {"endpoint_url": os.getenv("STORAGE_HOST") or None},
-            },
+            storage_options=None if file.startswith('http') else storage_options
         )
         for file in data_paths
     )


### PR DESCRIPTION
Per discussion under:

https://jataware.slack.com/archives/CAZTFECQY/p1681327107509529

The parquet file was located under a http[s] location and we were passing in storage_options, which raises an error when using our `pandas ` version:

https://github.com/pandas-dev/pandas/blob/v1.2.3/pandas/io/parquet.py#L69

This bugfix makes it so that we only pass in `storage_options` is data path location does not start with http/https. `storage_options` will still be passed in for s3 locations, as expected.