### PR TITLE
Bump to pandas version to alleviate bugs in elwood while running on R…

### DIFF
--- a/tasks/tasks/requirements.txt
+++ b/tasks/tasks/requirements.txt
@@ -6,7 +6,7 @@ numpy==1.22
 netCDF4==1.5.3
 matplotlib==3.5.2
 elwood==0.1.2
-pandas==1.2.3
+pandas==1.5.3
 python-dateutil==2.8.2
 raster2xyz==0.1.3
 requests==2.28.1

--- a/ui/client/datasets/DataTransformation/AdjustTemporalResolution.js
+++ b/ui/client/datasets/DataTransformation/AdjustTemporalResolution.js
@@ -18,7 +18,6 @@ const aggregationFunctions = [
   'size',
   'sum',
   'mean',
-  'average',
   'std',
   'var',
   'sem',


### PR DESCRIPTION
Bump to pandas version to alleviate bugs in Elwood while running on RQ worker. The older pandas versions have documented bugs with the resample and aggregation flows that have been fixed in newer versions.