### PR TITLE
Document explorer index fetch count 1000 increase

### DIFF
--- a/ui/client/components/SWRHooks.js
+++ b/ui/client/components/SWRHooks.js
@@ -198,7 +198,7 @@ export function useParams(modelId) {
 
 export function useDocuments(scrollId) {
 
-  let url = '/api/dojo/documents?size=100';
+  let url = '/api/dojo/documents?size=1000';
 
   if (scrollId) {
     url += `?scrollId=${scrollId}`;

--- a/ui/client/components/ViewFeatures.js
+++ b/ui/client/components/ViewFeatures.js
@@ -376,8 +376,7 @@ const ViewFeatures = withStyles((theme) => ({
       <DataGrid
         autoHeight
         components={{
-          LoadingOverlay: CustomLoadingOverlay,
-          Pagination: CustomTablePagination
+          LoadingOverlay: CustomLoadingOverlay
         }}
         loading={featuresLoading}
         getRowId={(row) => `${row.owner_dataset.id}-${row.name}`}

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -143,33 +143,6 @@ const fetchParagraphs = async (
 };
 
 /**
- * Uses internal DataGrid API to:
- * a) Decide if we should display "Many" for features count
- * b) Wire and display the rest of the labels that are usually
- *    set for us when we don't need custom behavior.
- */
-const CustomTablePagination = props => {
-
-  const { state, apiRef } = useGridSlotComponentProps();
-
-  return (
-    <TablePagination
-      labelDisplayedRows={({from, to, count}) => {
-        const displayCount = count > 500 ? 'Many' : count;
-        return `${from}-${to} of ${displayCount}`;
-      }}
-      {...props}
-      page={state.pagination.page}
-      onPageChange={(event, value) => {
-        return apiRef.current.setPage(value);
-      }}
-      rowsPerPage={100}
-      count={state.pagination.rowCount}
-    />
-  );
-};
-
-/**
  * Blue linear loading animation displayed when table loading/searching of
  * features is still in progress.
  */
@@ -596,8 +569,7 @@ const ViewDocumentsGrid = withStyles((theme) => ({
           <DataGrid
             autoHeight
             components={{
-              LoadingOverlay: CustomLoadingOverlay,
-              Pagination: CustomTablePagination
+              LoadingOverlay: CustomLoadingOverlay
             }}
             onRowClick={onDocumentRowClick}
             loading={documentsLoading || searchLoading}


### PR DESCRIPTION
Fetches up to 1000 documents when landing on the Document Explorer, if available.
Also removes the no-longer-used custom pagination component to let it handle changing rows per page.