### PR TITLE
Fixes Document Upload file list/PDF view mismatch

### DIFF
--- a/ui/client/documents/upload/index.js
+++ b/ui/client/documents/upload/index.js
@@ -166,7 +166,7 @@ const UploadDocumentForm = withStyles((theme) => ({
     setLoading(true);
     setAcceptedFilesCount(current => acceptedFiles.length + current);
 
-    const byteData = [];
+    const byteData = {};
 
     const pdfData = acceptedFiles.map((pdfFile) => {
       return readFile(pdfFile)
@@ -174,7 +174,7 @@ const UploadDocumentForm = withStyles((theme) => ({
           // Some side-effects on a map fn...
           const blob = new Blob([ bytes ], {type: "application/pdf"});
           const docUrl = URL.createObjectURL(blob);
-          byteData.push(docUrl);
+          byteData[pdfFile.path] = docUrl;
 
           return PDFDocument.load(bytes)
             .then(pdf => {
@@ -188,10 +188,11 @@ const UploadDocumentForm = withStyles((theme) => ({
     Promise.all(pdfData)
       .then((allPdfData) => {
         const formattedFiles = acceptedFiles
-              .map((file, idx) => {
-                file.blobUrl = byteData[idx];
-                return file;
-              });
+          .map((file) => {
+            // eslint-disable-next-line no-param-reassign
+            file.blobUrl = byteData[file.path];
+            return file;
+          });
 
         // Let's update the state all together when we have everything available.
         // It's hard to trust and coordinate batch updates when performing updates


### PR DESCRIPTION
There was a bug where the selected file in the left hand files list on /documents/upload wouldn't match the displayed PDF. We were matching the files to their blob url with an array index, which turned out to not be reliable. This switches to matching them with the file path. 

Currently there's nothing safeguarding against multiple files with the same path, or capping the number of files. Both of these can be added to this PR or done in a future PR. 