### PR TITLE
Adds 10 file limit for document upload

### DIFF
--- a/ui/client/datasets/annotations/Table/UploadAnnotationFileDialog.js
+++ b/ui/client/datasets/annotations/Table/UploadAnnotationFileDialog.js
@@ -1,8 +1,4 @@
-import React, { useRef, useState } from 'react';
-import clsx from 'clsx';
-import get from 'lodash/get';
-import find from 'lodash/find';
-import isEmpty from 'lodash/isEmpty';
+import React from 'react';
 
 import Alert from '@material-ui/lab/Alert';
 import Button from '@material-ui/core/Button';
@@ -13,12 +9,10 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
-import Typography from '@material-ui/core/Typography';
-
 import { FileDropSelector } from '../../../documents/upload/DropArea';
 
 export default ({
-  open, handleClose, handleFileSelect, handleDropFilesRejection,
+  open, handleClose, handleFileSelect,
   errorMessage, clearErrorMessage, loading, datasetID
 }) => (
   <Dialog
@@ -30,24 +24,25 @@ export default ({
     </DialogTitle>
 
     <DialogContent>
-       <DialogContentText variant="body2">
-         Download the template spreadsheet and include a row annotating dataset fields.
-       </DialogContentText>
+      <DialogContentText variant="body2">
+        Download the template spreadsheet and include a row annotating dataset fields.
+      </DialogContentText>
 
-      <div style={{display: 'relative'}}>
+      <div style={{ display: 'relative' }}>
         <FileDropSelector
           onFileSelect={handleFileSelect}
-          onDropFilesRejected={handleDropFilesRejection}
           acceptExtensions={['csv', 'xlsx']}
           CTA="Drop or Select a csv, xlsx"
           multiple={false}
         />
         {loading && (
-          <div style={{display: 'flex', justifyContent: 'center', alignItems: 'center'}}>
-              <CircularProgress
-                size={16}
-                disableShrink
-              /> &nbsp; <span>Uploading</span>
+          <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+            <CircularProgress
+              size={16}
+              disableShrink
+            />
+            &nbsp;
+            <span>Uploading</span>
           </div>
         )}
       </div>
@@ -55,7 +50,8 @@ export default ({
       <Button
         component="a"
         href={`/api/dojo/indicators/annotations/file-template${datasetID ? '?indicator_id='+datasetID : ''}`}
-        color="primary">
+        color="primary"
+      >
         Download template
       </Button>
 

--- a/ui/client/datasets/annotations/Table/index.js
+++ b/ui/client/datasets/annotations/Table/index.js
@@ -4,31 +4,25 @@ import clsx from 'clsx';
 import get from 'lodash/get';
 import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
-import axios from 'axios';
 
 import { withStyles } from '@material-ui/core/styles';
 import { GridOverlay, DataGrid } from '@material-ui/data-grid';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
-import IconButton from '@material-ui/core/IconButton';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import InboxIcon from '@material-ui/icons/MoveToInbox';
 
-import { calcPointerLocation, groupColumns } from './helpers';
+import { groupColumns } from './helpers';
 import BasicAlert from '../../../components/BasicAlert';
 import ColumnPanel from '../ColumnPanel';
 import Header from './Header';
 
 import AnnotationDialog from './UploadAnnotationFileDialog';
-import { FileDropSelector } from '../../../documents/upload/DropArea';
 
 const rowsPerPageOptions = [25, 50, 100];
 
-/**
- *
- * */
 const Cell = withStyles(({ palette, spacing }) => ({
   root: {
     marginLeft: -6,
@@ -65,16 +59,12 @@ function CustomLoadingOverlay() {
   return (
     <GridOverlay>
       <div style={{ position: 'absolute', top: 0, width: '100%', zIndex: 15 }}>
-        <LinearProgress style={{height: 3}}/>
+        <LinearProgress style={{ height: 3 }} />
       </div>
     </GridOverlay>
   );
 }
 
-
-/**
- *
- * */
 export default withStyles(({ palette }) => ({
   root: {
     display: 'flex',
@@ -297,7 +287,6 @@ export default withStyles(({ palette }) => ({
   };
 
   const handleFileSelect = (acceptedFiles) => {
-
     setDictionaryUploadLoading(true);
     onUploadAnnotations(acceptedFiles[0])
       .then((success) => {
@@ -306,7 +295,7 @@ export default withStyles(({ palette }) => ({
         if (success) {
           setAnnotationSuccessAlert(true);
           setAnnotationAlertMessage({
-            message: `Your annotations were successfully applied`,
+            message: 'Your annotations were successfully applied',
             severity: 'success'
           });
         }
@@ -317,23 +306,11 @@ export default withStyles(({ palette }) => ({
       .finally(() => { setDictionaryUploadLoading(false); });
   };
 
-  const handleDropFilesRejection = (error) => {
-    let errorMessage = `The data dictionary file was rejected. `;
-
-    try {
-      errorMessage += error[0].errors.map(item => item.message).join('\n');
-    } catch(e) {
-      errorMessage += 'Only one CSV file allowed at a time.';
-    }
-
-    setfileDictionaryError(errorMessage);
-  };
-
   return (
     <div className={classes.root}>
 
-      <div style={{display: 'flex'}}>
-        <div style={{flex: 1}}>
+      <div style={{ display: 'flex' }}>
+        <div style={{ flex: 1 }}>
           <Tooltip
             classes={{ tooltip: classes.tooltip }}
             title="Display context icons for columns with inferred data, annotated as primary, or as qualifier."
@@ -352,7 +329,7 @@ export default withStyles(({ palette }) => ({
         </div>
 
         {addingAnnotationsAllowed && (
-          <div style={{display: 'flex', alignItems: 'center'}}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
             <Button
               color="primary"
               size="large"
@@ -428,7 +405,6 @@ export default withStyles(({ palette }) => ({
         open={isUploadingAnnotations}
         handleClose={cancelUploadAnnotations}
         handleFileSelect={handleFileSelect}
-        handleDropFilesRejection={handleDropFilesRejection}
         errorMessage={fileDictionaryError}
         clearErrorMessage={()=>{setfileDictionaryError(null);}}
         loading={dictionaryUploadLoading}

--- a/ui/client/documents/upload/DropArea.js
+++ b/ui/client/documents/upload/DropArea.js
@@ -27,9 +27,9 @@ const extensionMap = {
 export function formatExtensionForDropZone(extensionsArray) {
   return extensionsArray.reduce((acc, extension) => {
     // Optional preceding dot . for extension removed
-    let buff = extension.replace(/^\./g, '');
+    const buff = extension.replace(/^\./g, '');
 
-    return {...acc, ...extensionMap[buff]};
+    return { ...acc, ...extensionMap[buff] };
   }, {});
 }
 
@@ -74,13 +74,19 @@ export const FileDropSelector = withStyles((theme => ({
   const [alertMessage, setAlertMessage] = useState('');
 
   const onDropFilesRejected = (fileRejections) => {
-    if (fileRejections.length > 10) {
-      setAlertMessage('The upload limit is 10 files. Please try again with fewer files.');
-      setAlertVisible(true);
+    let errorMessage = 'There was an issue with your file upload: ';
+
+    if (fileRejections.length > 10 && acceptExtensions.includes('pdf')) {
+      errorMessage += 'The upload limit is 10 files. Please try again with fewer files.';
+    } else if (fileRejections[0].errors) {
+      errorMessage += fileRejections[0].errors.map((item) => item?.message).join('; ');
     } else {
-      setAlertMessage(fileRejections[0].errors[0].message);
-      setAlertVisible(true);
+      errorMessage += `Your file(s) could not be processed.
+        Please check that the number of files and the file extension(s) are correct.`;
     }
+
+    setAlertMessage(errorMessage);
+    setAlertVisible(true);
   };
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
@@ -93,7 +99,7 @@ export const FileDropSelector = withStyles((theme => ({
   });
 
   useEffect(() => {
-    // stop drag and drop behavior when we want to disable the drop area
+    // stop default browser drag and drop behavior when we want to disable the drop area
     // eg when the user has added the max number of files
     const preventDefaultDragAndDrop = (e) => {
       e.preventDefault();

--- a/ui/client/documents/upload/index.js
+++ b/ui/client/documents/upload/index.js
@@ -26,7 +26,6 @@ import { SelectedFileList } from './FileList';
 import EditMetadata from './EditMetadata';
 import PDFViewer from './PDFViewer';
 
-
 const PDF_ATTR_GETTERS = [
   'getTitle',
   'getAuthor',
@@ -267,10 +266,6 @@ const UploadDocumentForm = withStyles((theme) => ({
     console.log("deleting file index:", index);
   };
 
-  const handleDropFilesRejection = ({errors, file}, event) => {
-    console.log("some file types were rejected. They should be a pdf type.");
-  };
-
   return (
     <Container
       className={classes.root}
@@ -304,7 +299,7 @@ const UploadDocumentForm = withStyles((theme) => ({
 
         <FileDropSelector
           onFileSelect={handleFileSelect}
-          onDropFilesRejected={handleDropFilesRejection}
+          disableSelector={files.length >= 10}
         />
 
         {loading && (
@@ -412,7 +407,6 @@ const UploadDocumentForm = withStyles((theme) => ({
 
         )}
       </div>
-
     </Container>
   );
 });


### PR DESCRIPTION
This PR adds a 10 file limit for the document uploader. It's possible to circumvent the limit by adding up to 9 files, then adding up to 10 more. However, with the 10 file cap per drag&drop/selector, and the entire uploader disabled after it passes 10, the maximum a user can reach is 19 with this workaround. 

I also added alert-based error messaging when the file picker/drag & drop fails, either because too many documents were added or for another reason (screenshot below). 

![Screenshot 2023-05-03 at 6 36 25 PM](https://user-images.githubusercontent.com/2448578/236065729-8cefa4fc-7302-47f2-9625-8c74bf597889.png)
