### PR TITLE
Delete files in Document Uploader

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
     "camelcase": "off",
     "jsx-a11y/alt-text": "warn",
     "react/jsx-props-no-multi-spaces": "off",
-
+    "spaced-comment": ["error", "always", { "block": { "exceptions": ["*"] } }],
     "sort-imports": ["error", {
       "ignoreCase": false,
       "ignoreDeclarationSort": true,

--- a/ui/client/documents/upload/FileList.js
+++ b/ui/client/documents/upload/FileList.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 
-import { formatBytes } from '../utils';
-
+import ClearIcon from '@material-ui/icons/Clear';
+import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
@@ -13,10 +13,9 @@ import Paper from '@material-ui/core/Paper';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 
-/**
- *
- **/
-export const FileTile = withStyles((theme) => ({
+import { formatBytes } from '../utils';
+
+export const FileTile = withStyles(() => ({
   root: {
     cursor: 'pointer'
   },
@@ -36,7 +35,13 @@ export const FileTile = withStyles((theme) => ({
   filenameText: {
     wordBreak: 'break-all'
   }
-}))(({ classes, file, value, uploadStatus, onClick, selected, onDelete }) => {
+}))(({
+  classes, file, value, onClick, selected, onDelete
+}) => {
+  const handleDeleteClick = (event) => {
+    event.stopPropagation();
+    onDelete();
+  };
 
   return (
     <ListItem
@@ -51,26 +56,22 @@ export const FileTile = withStyles((theme) => ({
       </ListItemIcon>
 
       <ListItemText
-        classes={{primary: classes.filenameText}}
+        classes={{ primary: classes.filenameText }}
         primary={file.name}
         secondary={`Size: ${formatBytes(file.size)}`}
       />
 
-      {/* TODO Add delete icon when we need it, implement handler. */}
-      {/* <ListItemSecondaryAction> */}
-      {/*   <IconButton edge="end" aria-label="delete" onClick={onDelete}> */}
-      {/*     <ClearIcon /> */}
-      {/*   </IconButton> */}
-      {/* </ListItemSecondaryAction> */}
+      <ListItemSecondaryAction>
+        <IconButton edge="end" aria-label="delete" onClick={handleDeleteClick}>
+          <ClearIcon />
+        </IconButton>
+      </ListItemSecondaryAction>
 
     </ListItem>
   );
 });
 
-/**
- *
- **/
-export const SelectedFileList = withStyles((theme) => ({
+export const SelectedFileList = withStyles(() => ({
   root: {
     border: '1px solid #eaeaea',
     borderRadius: 0,
@@ -87,37 +88,35 @@ export const SelectedFileList = withStyles((theme) => ({
     right: 0,
     backgroundColor: 'white'
   }
-}))(({ classes, files, onItemClick, onDelete, selectedIndex }) => {
-
-  return (
-    <Paper
-      className={classes.root}
+}))(({
+  classes, files, onItemClick, onDelete, selectedIndex
+}) => (
+  <Paper
+    className={classes.root}
+  >
+    <RadioGroup
+      value={selectedIndex+""}
     >
-      <RadioGroup
-        value={selectedIndex+""}
+
+      <List
+        subheader={(
+          <ListSubheader component="div">
+            Files
+          </ListSubheader>
+        )}
+        className={classes.list}
       >
-
-        <List
-          subheader={
-            <ListSubheader component="div">
-              Files
-            </ListSubheader>
-          }
-          className={classes.list}
-        >
-          {files.map((file, index) => file && (
-            <FileTile
-              onDelete={() => onDelete(index)}
-              selected={index === selectedIndex}
-              onClick={() => onItemClick(index)}
-              value={index+""}
-              file={file}
-              key={file.path+file.size}
-            />
-          ))}
-        </List>
-      </RadioGroup>
-    </Paper>
-  );
-});
-
+        {files.map((file, index) => file && (
+          <FileTile
+            onDelete={() => onDelete(index)}
+            selected={index === selectedIndex}
+            onClick={() => onItemClick(index)}
+            value={index+""}
+            file={file}
+            key={file.path+file.size}
+          />
+        ))}
+      </List>
+    </RadioGroup>
+  </Paper>
+));

--- a/ui/client/documents/upload/FileList.js
+++ b/ui/client/documents/upload/FileList.js
@@ -15,6 +15,9 @@ import Radio from '@material-ui/core/Radio';
 
 import { formatBytes } from '../utils';
 
+/**
+ *
+ **/
 export const FileTile = withStyles(() => ({
   root: {
     cursor: 'pointer'
@@ -71,6 +74,9 @@ export const FileTile = withStyles(() => ({
   );
 });
 
+/**
+ *
+ **/
 export const SelectedFileList = withStyles(() => ({
   root: {
     border: '1px solid #eaeaea',

--- a/ui/client/documents/upload/index.js
+++ b/ui/client/documents/upload/index.js
@@ -145,7 +145,7 @@ const UploadDocumentForm = withStyles((theme) => ({
 
   const [files, setFiles] = useState([]);
   const [allPDFMetadata, setAllPDFMetadata] = useState([]);
-  const [selectedFileIndex, setSelectedFileIndex] = useState(null);
+  const [selectedFileIndex, setSelectedFileIndex] = useState(0);
 
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -153,7 +153,7 @@ const UploadDocumentForm = withStyles((theme) => ({
   const [acceptedFilesCount, setAcceptedFilesCount] = useState(0);
   const [acceptedFilesParsed, setAcceptedFilesParsed] = useState(0);
 
-  const selectedFile = selectedFileIndex !== null ? files[selectedFileIndex] : {};
+  const selectedFile = files[selectedFileIndex] || {};
 
   const history = useHistory();
 
@@ -193,8 +193,8 @@ const UploadDocumentForm = withStyles((theme) => ({
         // Let's update the state all together when we have everything available.
         // It's hard to trust and coordinate batch updates when performing updates
         // both outside and inside async promise handler:
-        setAllPDFMetadata(prevMetadata => [ ...prevMetadata, ...allPdfData ]);
-        setFiles(prevFiles => [ ...prevFiles, ...formattedFiles ]);
+        setAllPDFMetadata(prevMetadata => [...prevMetadata, ...allPdfData]);
+        setFiles(prevFiles => [...prevFiles, ...formattedFiles]);
         setSelectedFileIndex(selectedFileIndex => selectedFileIndex || 0);
 
         setLoading(false);
@@ -202,7 +202,6 @@ const UploadDocumentForm = withStyles((theme) => ({
         setAcceptedFilesCount(0);
         setAcceptedFilesParsed(0);
       });
-
   };
 
   /**
@@ -220,29 +219,26 @@ const UploadDocumentForm = withStyles((theme) => ({
   };
 
   const submitAndUploadDocuments = () => {
-
     setUploading(true);
-
     files.forEach((file, idx) => {
-
       // We use the parsed doc Date object type until the very last minute
       // so that the UI calendar widget can work properly, and then we
       // format for the server before submitting.
-      const metadataClone = {...allPDFMetadata[idx]};
+      const metadataClone = { ...allPDFMetadata[idx] };
       metadataClone.creation_date = formatDate(metadataClone.creation_date);
 
       const documentsPromise = axios({
         method: 'post',
-        url: `/api/dojo/documents`,
+        url: '/api/dojo/documents',
         data: metadataClone,
         params: {}
       }).catch((e) => {
         console.log('Error creating doc', e);
-      }).then(response => {
+      }).then((response) => {
         const doc = response.data;
         return uploadFile(file, `/api/dojo/documents/${doc.id}/upload`, {});
       }).catch((e) => {
-        console.log("Error uploading files", e);
+        console.log('Error uploading files', e);
       }).then(() => {
         history.push('/documents');
       });
@@ -262,7 +258,7 @@ const UploadDocumentForm = withStyles((theme) => ({
     <Container
       className={classes.root}
       component="main"
-      maxWidth={selectedFileIndex === null ? "md" : false}
+      maxWidth={isEmpty(files) ? 'md' : false}
     >
       <Typography
         variant="h3"
@@ -282,7 +278,7 @@ const UploadDocumentForm = withStyles((theme) => ({
 
       <div className={classes.mainContent}>
         <Alert
-          style={{border: "none"}}
+          style={{ border: 'none' }}
           severity="info"
           variant="outlined"
         >
@@ -297,7 +293,7 @@ const UploadDocumentForm = withStyles((theme) => ({
         {loading && (
           <div>
             <br />
-            <div style={{display: 'flex', alignItems: 'center'}}>
+            <div style={{ display: 'flex', alignItems: 'center' }}>
               <CustomLoading
                 variant="determinate"
                 value={(acceptedFilesParsed / acceptedFilesCount) * 100}
@@ -312,22 +308,19 @@ const UploadDocumentForm = withStyles((theme) => ({
         )}
 
         {!isEmpty(files) && (
-          <div style={{
-            flex: '3 0 auto'
-          }}>
-
+          <div style={{ flex: '3 0 auto' }}>
             <Alert
-              style={{border: "none", paddingTop: '0.5rem'}}
+              style={{ border: 'none', paddingTop: '0.5rem' }}
               severity="info"
               variant="outlined"
             >
-              The following {files.length > 1 ? `${files.length} files` : "file"} will be uploaded. Confirm or edit
+              The following {files.length > 1 ? `${files.length} files` : 'file'} will be uploaded. Confirm or edit
               document metadata fields before proceeding.
             </Alert>
 
             <div className={classes.fileList}>
 
-              <section style={{flex: '4 2 400px', padding: '1rem'}}>
+              <section style={{ flex: '4 2 400px', padding: '1rem' }}>
                 <SelectedFileList
                   onDelete={handleFileDelete}
                   files={files}
@@ -336,28 +329,23 @@ const UploadDocumentForm = withStyles((theme) => ({
                 />
               </section>
 
-              {selectedFileIndex !== null && (
-                <section style={{flex: '6 2 400px'}}>
-                  <PDFViewer
-                    file={selectedFile}
-                  />
-                </section>
-              )}
+              <section style={{ flex: '6 2 400px' }}>
+                <PDFViewer
+                  file={selectedFile}
+                />
+              </section>
 
-              {selectedFileIndex !== null && (
-                <section
-                  style={{flex: '4 1 500px'}}
-                >
-                  {/* NOTE key==selectedIndex renders a form per file, but only for the file in question; */}
-                  {/*   shorthand for adding a form per file, only displaying selected file form */}
-                  <EditMetadata
-                    key={selectedFileIndex}
-                    onSave={handleDocFieldChange}
-                    filename={selectedFile.name}
-                    metadata={allPDFMetadata[selectedFileIndex]} />
-                </section>
-              )}
+              <section style={{ flex: '4 1 500px' }}>
 
+                {/* key==selectedIndex renders a form per file, but only for the file in question;
+                  shorthand for adding a form per file, only displaying selected file form */}
+                <EditMetadata
+                  key={selectedFileIndex}
+                  onSave={handleDocFieldChange}
+                  filename={selectedFile.name}
+                  metadata={allPDFMetadata[selectedFileIndex]}
+                />
+              </section>
             </div>
 
             <div className={classes.navContainer}>
@@ -371,7 +359,7 @@ const UploadDocumentForm = withStyles((theme) => ({
               &nbsp;
               {uploading ? (
                 <div>
-                  <div style={{display: 'flex', alignItems: 'center'}}>
+                  <div style={{ display: 'flex', alignItems: 'center' }}>
                     <CustomLoading
                       variant="indeterminate"
                     />

--- a/ui/client/documents/upload/index.js
+++ b/ui/client/documents/upload/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import axios from 'axios';
 import isEmpty from 'lodash/isEmpty';
@@ -6,16 +6,13 @@ import snakeCase from 'lodash/snakeCase';
 
 import { PDFDocument } from 'pdf-lib';
 
-// import ClearIcon from '@material-ui/icons/Clear';
 import Alert from '@material-ui/lab/Alert';
 import Button from '@material-ui/core/Button';
 import Container from '@material-ui/core/Container';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import LinearProgress from '@material-ui/core/LinearProgress';
 import Typography from '@material-ui/core/Typography';
 
 import { withStyles } from '@material-ui/core/styles';
-// import get from 'lodash/get';
 
 import { readFile } from '../utils';
 
@@ -249,21 +246,16 @@ const UploadDocumentForm = withStyles((theme) => ({
       }).then(() => {
         history.push('/documents');
       });
-
-      // if we map files to promises to await all uploads:
-      // return documentsPromise;
-
     });
   };
 
-  /**
-   * TODO: In order to handle deletes- either do backflips around deleted indexes,
-   * not rendering deleted ones, etc, or change the collection/representation
-   * of data from arrays and selected index to an object with key=>properties.
-   **/
   const handleFileDelete = (index) => {
-    // TODO Implement me once we use SortedMap
-    console.log("deleting file index:", index);
+    // always reset back to zero, even if we aren't touching the selectedFile
+    // so we don't end up in a weird state where we're modifying the array around this index
+    setSelectedFileIndex(0);
+    // remove the file at the index from both the metadata and files arrays
+    setAllPDFMetadata((prev) => [...prev.slice(0, index), ...prev.slice(index + 1)]);
+    setFiles((prev) => [...prev.slice(0, index), ...prev.slice(index + 1)]);
   };
 
   return (


### PR DESCRIPTION
This PR adds delete buttons to the files in the document uploader. The functionality is straightforward, with a single caveat: it will currently always reset the selected file to the first file in the list. Because of the way we're managing the files (two different arrays for the files and the metadata) and the selected file (a reference to the index), this seemed like the simplest and safest way of handling the variety of cases where a user may delete the selected file, delete a file before the selected file (thus changing where the index is pointing), etc. We can do a more complex handling of this if we want, but I think anything else will be more likely to introduce bugs. 

Considering that there's a 10 file limit (and that any edits to the metadata form persist when switching between files), this shouldn't be taxing for users. 