### PR TITLE
Document Paragraph Search: clean non-word characters from query

### DIFF
--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1,7 +1,5 @@
-# import os
 import sys
-# import pytest
 from pathlib import Path
 
-# Add this folder to pythonpath so that test can see all modules (under src/*)
+# Adding api/ to pythonpath so that test can see all modules within (eg src.*)
 sys.path.append(str(Path(__file__).resolve().parent))

--- a/api/conftest.py
+++ b/api/conftest.py
@@ -1,0 +1,7 @@
+# import os
+import sys
+# import pytest
+from pathlib import Path
+
+# Add this folder to pythonpath so that test can see all modules (under src/*)
+sys.path.append(str(Path(__file__).resolve().parent))

--- a/api/src/csv_annotation_parser_test.py
+++ b/api/src/csv_annotation_parser_test.py
@@ -1,10 +1,3 @@
-import pytest
-
-import sys
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-
-# Append out project python path for easier file-module resolution
 from src.csv_annotation_parser import format_annotations, format_schema_helper
 
 """

--- a/api/src/urls.py
+++ b/api/src/urls.py
@@ -6,7 +6,7 @@ def clean_and_decode_str(text: str) -> str:
     """
     Given a `text` input string that is optionally url encoded, decodes
     it and strips special, non-word, characters out (eg %, ^, &, $, >, etc)
-    and returns the clean and easy to word text only.
+    and returns the clean, easy to read and semantic search, text only.
     """
 
     # Handle case when encoding spaces with `+` instead of %20

--- a/api/src/urls.py
+++ b/api/src/urls.py
@@ -1,0 +1,16 @@
+import re
+import urllib.parse
+
+
+def clean_and_decode_str(text: str) -> str:
+    """
+    Given a `text` input string that is optionally url encoded, decodes
+    it and strips special, non-word, characters out (eg %, ^, &, $, >, etc)
+    and returns the clean and easy to word text only.
+    """
+
+    # Handle case when encoding spaces with `+` instead of %20
+    text = text.replace('+',' ')
+    url_decoded = urllib.parse.unquote(text)
+
+    return ' '.join(re.sub(r'[^\w\s]', '', url_decoded).split())

--- a/api/src/urls_test.py
+++ b/api/src/urls_test.py
@@ -14,6 +14,7 @@ def test_clean_and_decode_str():
               "test % test",
               # weird technique of encoding spaces with `+` scenario
               "Population+per+3km+square+resolution",
+              "I am a paragraph with punctuation; actually, I'm a sentence."
               ]
 
     outputs = ["Hello World",
@@ -31,6 +32,8 @@ def test_clean_and_decode_str():
                "test test",
                # Replaces + with spaces, does not remove them
                "Population per 3km square resolution",
+               # Looks bad, but semantic search performs better(!):
+               "I am a paragraph with punctuation actually Im a sentence"
                ]
 
     for idx, item in enumerate(inputs):

--- a/api/src/urls_test.py
+++ b/api/src/urls_test.py
@@ -1,0 +1,38 @@
+from src.urls import clean_and_decode_str
+
+def test_clean_and_decode_str():
+
+    inputs = ["Hello World #$*(&)",
+              "hiya!",
+              "Natural Resources and Mineral rents",
+              "Natural%20Resources%20and%20Mineral%20rents",
+              "searching%20%3E%20%%20symbol",
+              "search #$&*^ #$* symbol2",
+              "co%de !@#$%^&*() well",
+              "co%20e !@#$%^&*() well",
+              "co$e !@#$%^&*() well",
+              "test % test",
+              # weird technique of encoding spaces with `+` scenario
+              "Population+per+3km+square+resolution",
+              ]
+
+    outputs = ["Hello World",
+               "hiya",
+               # Sentences with no special chars are preserved
+               "Natural Resources and Mineral rents",
+               #  same result for input spaces url encoded:
+               "Natural Resources and Mineral rents",
+               "searching symbol",
+               "search symbol2",
+               # Notice how %de breaks encoding and causes the `e` to disappear:
+               "co well",
+               "co e well",
+               "coe well", # $ is gone-> not a special url encoding char like %
+               "test test",
+               # Replaces + with spaces, does not remove them
+               "Population per 3km square resolution",
+               ]
+
+    for idx, item in enumerate(inputs):
+        assert clean_and_decode_str(item) == outputs[idx], \
+            f"Item={item} at index={idx} failed"


### PR DESCRIPTION
This improves the results accuracy. Symbols, and even punctuation, would bubble up more nonsense unrelated to the words of the query.

This aims to address the way uncharted was sending the document search query to dojo, which concatenated strings using `+` from my inspection. Uncharted had informed me that they were encoding the uri, which I wasn't to exactly reproduce as an issue on our side (since I saw they used `+` instead of `%20`), but fastapi already decodes url.

# Testing

See unit tests on PR diff.

Post-merge-Update Jun-8-2023: since deployment, we've gotten reports that this might not have had the desired effects during integration tests (on actual deployments), and we'll need to look into it.