### PR TITLE
Document Explorer Pagination

### DIFF
--- a/api/src/documents.py
+++ b/api/src/documents.py
@@ -331,10 +331,8 @@ def list_documents(scroll_id: Optional[str]=None, size: int = 10):
     }
 
     if not scroll_id:
-        logger.info("NOT SCROLL ID")
         results = es.search(index="documents", body=q, scroll="2m", size=size)
     else:
-        logger.info("WE HAVE A SCROLLID")
         results = es.scroll(scroll_id=scroll_id, scroll="2m")
 
     totalDocsInPage = len(results["hits"]["hits"])

--- a/api/src/documents.py
+++ b/api/src/documents.py
@@ -331,8 +331,10 @@ def list_documents(scroll_id: Optional[str]=None, size: int = 10):
     }
 
     if not scroll_id:
+        logger.info("NOT SCROLL ID")
         results = es.search(index="documents", body=q, scroll="2m", size=size)
     else:
+        logger.info("WE HAVE A SCROLLID")
         results = es.scroll(scroll_id=scroll_id, scroll="2m")
 
     totalDocsInPage = len(results["hits"]["hits"])

--- a/ui/client/components/SWRHooks.js
+++ b/ui/client/components/SWRHooks.js
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 
-const fetcher = async (url) => {
+export const fetcher = async (url) => {
   const response = await fetch(url);
 
   if (!response.ok) {
@@ -196,25 +196,24 @@ export function useParams(modelId) {
   };
 }
 
-export function useDocuments(scrollId) {
+// export function useDocuments(scrollId) {
+//   let url = '/api/dojo/documents?size=20';
 
-  let url = '/api/dojo/documents?size=1000';
+//   if (scrollId) {
+//     url += `?scrollId=${scrollId}`;
+//   }
 
-  if (scrollId) {
-    url += `?scrollId=${scrollId}`;
-  }
+//   const { data, error, mutate } = useSWR(
+//     url, fetcher, {
+//       revalidateIfStale: false,
+//       revalidateOnFocus: false,
+//       revalidateOnReconnect: false
+//     }
+//   );
 
-  const { data, error, mutate } = useSWR(
-    url, fetcher, {
-      revalidateIfStale: false,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false
-    }
-  );
-
-  return {
-    documents: data,
-    documentsLoading: !error && !data,
-    documentsError: error,
-  };
-}
+//   return {
+//     documents: data,
+//     documentsLoading: !error && !data,
+//     documentsError: error,
+//   };
+// }

--- a/ui/client/components/SWRHooks.js
+++ b/ui/client/components/SWRHooks.js
@@ -1,6 +1,6 @@
 import useSWR from 'swr';
 
-export const fetcher = async (url) => {
+const fetcher = async (url) => {
   const response = await fetch(url);
 
   if (!response.ok) {
@@ -195,25 +195,3 @@ export function useParams(modelId) {
     paramsError: error,
   };
 }
-
-// export function useDocuments(scrollId) {
-//   let url = '/api/dojo/documents?size=20';
-
-//   if (scrollId) {
-//     url += `?scrollId=${scrollId}`;
-//   }
-
-//   const { data, error, mutate } = useSWR(
-//     url, fetcher, {
-//       revalidateIfStale: false,
-//       revalidateOnFocus: false,
-//       revalidateOnReconnect: false
-//     }
-//   );
-
-//   return {
-//     documents: data,
-//     documentsLoading: !error && !data,
-//     documentsError: error,
-//   };
-// }

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -401,7 +401,7 @@ const ViewDocumentsGrid = withStyles(() => ({
         try {
           const response = await axios.get(
             // eslint-disable-next-line prefer-template
-            `/api/dojo/documents?size=20${scrollIdRef.current ? '&scroll_id=' + scrollIdRef.current : ''}`
+            `/api/dojo/documents?size=100${scrollIdRef.current ? '&scroll_id=' + scrollIdRef.current : ''}`
           );
 
           const { data } = response;
@@ -635,7 +635,7 @@ const ViewDocumentsGrid = withStyles(() => ({
                 loading={documentsLoading || searchLoading}
                 columns={displayableColumns}
                 rows={documents?.results || []}
-                pageSize={20}
+                pageSize={100}
                 onPageChange={handlePageChange}
                 paginationMode="server"
                 rowCount={totalRowsCount}

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -386,7 +386,8 @@ const ViewDocumentsGrid = withStyles((theme) => ({
   // let url = `/api/dojo/documents?size=20&page=${page}`;
   // if (scrollIdRef.current) url += `?scroll_id=${scrollIdRef.current}`
   const { data: documentsData, error: documentsError } = useSWR(
-    `/api/dojo/documents?size=20&page=${page}${scrollIdRef.current ? '?scroll_id=' + scrollIdRef.current : '' }`,
+    `/api/dojo/documents?size=20
+      ${scrollIdRef.current ? '&scroll_id=' + scrollIdRef.current : ''}&page=${page}`,
     fetcher,
     {
       revalidateIfStale: false,

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -1,15 +1,14 @@
-import React, { useCallback, useEffect, useRef, useState, } from 'react';
+import React, {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
 
-import useSWR from 'swr';
 import axios from 'axios';
 import debounce from 'lodash/debounce';
 
 import Button from '@material-ui/core/Button';
-import { GridOverlay, DataGrid, useGridSlotComponentProps } from '@material-ui/data-grid';
+import { GridOverlay, DataGrid } from '@material-ui/data-grid';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
-import TablePagination from '@material-ui/core/TablePagination';
-import Alert from '@material-ui/lab/Alert';
 
 import LinearProgress from '@material-ui/core/LinearProgress';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -25,7 +24,6 @@ import get from 'lodash/get';
 
 import Container from '@material-ui/core/Container';
 import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -33,7 +31,6 @@ import Divider from '@material-ui/core/Divider';
 
 import { Link as RouteLink } from 'react-router-dom';
 
-import { fetcher } from "../components/SWRHooks";
 import { calculateHighlightTargets } from "./utils";
 
 import ExpandableDataGridCell from "../components/ExpandableDataGridCell";
@@ -387,10 +384,13 @@ const ViewDocumentsGrid = withStyles(() => ({
   const [documentsLoading, setDocumentsLoading] = useState(false);
 
   const fetchData = useCallback(
+    // we use DataGrid's page index to maintain a cache for what DG should display
+    // on each page of results. The API just uses a scroll_id and has no notion of this page
     async (page) => {
       setDocumentsLoading(true);
       setDocumentsError(null);
       // clear documents when loading so that we don't display the previous page
+      // before loading the next set of results
       setDocuments(null);
 
       // check if data for the page is already in the cache
@@ -401,7 +401,7 @@ const ViewDocumentsGrid = withStyles(() => ({
         try {
           const response = await axios.get(
             // eslint-disable-next-line prefer-template
-            `/api/dojo/documents?size=20${scrollIdRef.current ? '&scroll_id=' + scrollIdRef.current : ''}&page=${page}`
+            `/api/dojo/documents?size=20${scrollIdRef.current ? '&scroll_id=' + scrollIdRef.current : ''}`
           );
 
           const { data } = response;
@@ -433,7 +433,8 @@ const ViewDocumentsGrid = withStyles(() => ({
 
   // fetch the rows out of the cache for page 0 so that we maintain it even when we clear
   // documents state on page change, defaulting to 0 to prevent NaN in case we have no hits
-  const totalRowsCount = Number(documents?.hits) || cachedDocumentsRef.current[0]?.hits || 0;
+  const totalRowsCount = Number(documents?.hits)
+    || Number(cachedDocumentsRef.current[0]?.hits) || 0;
 
   const handlePageChange = (params) => {
     fetchData(params);
@@ -504,9 +505,6 @@ const ViewDocumentsGrid = withStyles(() => ({
         setSearchLoading(false);
       });
   };
-
-
-console.log('documents', documents)
 
   useEffect(() => {
     performSearch();


### PR DESCRIPTION
This adds pagination to the document explorer. It generally works as expected.

One caveat, as discussed on Slack: it's possible that on very slow connections, some users may experience some loading order issues if they click through multiple pages of results before those pages finish loading. Disabling the `next` arrow is unfortunately not supported by our current version of MUI DataGrid (and would thus be fairly time consuming to hack together). However, if it becomes an issue, we can implement a very easy fix by getting rid of the pagination buttons altogether while we're in the loading state. This will also prevent them from going back to the previous page while content loads, but will stop the rapid click loading order issue from cropping up. 