### PR TITLE
Added causemos plugin example to envfile.sample.

### DIFF
--- a/envfile.sample
+++ b/envfile.sample
@@ -41,3 +41,4 @@ UVICORN_RELOAD=True
 #DOCUMENT_STORAGE_BASE_URL=s3://jataware-world-modelers-dev/documents/
 DOCUMENT_STORAGE_BASE_URL=file:///documents/
 DISABLE_SEMANTIC_HIGHLIGHT=false
+PLUGINS={"causemos":"src.plugins.causemos.CausemosPlugin","logger":"src.plugins.logging.LoggingPlugin"}

--- a/envfile.sample
+++ b/envfile.sample
@@ -41,4 +41,4 @@ UVICORN_RELOAD=True
 #DOCUMENT_STORAGE_BASE_URL=s3://jataware-world-modelers-dev/documents/
 DOCUMENT_STORAGE_BASE_URL=file:///documents/
 DISABLE_SEMANTIC_HIGHLIGHT=false
-PLUGINS={"causemos":"src.plugins.causemos.CausemosPlugin","logger":"src.plugins.logging.LoggingPlugin"}
+PLUGINS={"causemos":"src.plugins.causemos.CausemosPlugin","logger":"src.plugins.logging.LoggingPlugin", "sync":"src.plugins.sync.SyncPlugin"}


### PR DESCRIPTION
Pending items:

- Add mock `test-app` docker service to received plugin/published messages. Possibly rename for something more meaningful for this purpose. Covered by open #89 

## Questions

- I'm not completely familiar with the causemos publish setup- does `DEBUG=true` cause it to skip publishing altogether?
Addressed on a call and the answer is YES- debug=true would historically cause causemos to not be notified (which we want for local dev)
- Should we add an entry to dojo-stack/README or api/README on how to setup and/or use the publishing plugin?
The answer is YES- we'll addres either on #89 or after it is merged.