### PR TITLE
Added new sync plugin

### DIFF
--- a/api/src/plugins/sync.py
+++ b/api/src/plugins/sync.py
@@ -1,0 +1,124 @@
+import json
+
+import requests
+from fastapi.logger import logger
+from src.plugins import PluginInterface
+from src.indicators import update_indicator
+from src.data import get_context
+from validation import IndicatorSchema
+
+
+class SyncPlugin(PluginInterface):
+
+    # Sync annotations to indicators
+    def publish(self, data, type="indicator"):
+        if type == "indicator":
+            uuid = data["id"]
+            context = get_context(uuid)
+
+            # Outputs
+            qualifier_outputs = []
+            outputs = []
+            feature_names = []
+            for feature in context["annotations"]["annotations"]["feature"]:
+
+                feature_names.append(
+                    feature["name"]
+                )  # Used for the primary qualifier outputs.
+                output = dict(
+                    name=feature["name"],
+                    display_name=feature["display_name"],
+                    description=feature["description"],
+                    type=feature["feature_type"],
+                    unit=feature["units"],
+                    unit_description=feature["units_description"],
+                    ontologies={},
+                    is_primary=True,
+                    data_resolution={
+                        "temporal_resolution": context.get("dataset", {}).get(
+                            "temporal_resolution", None
+                        ),
+                        "spatial_resolution": context.get("dataset", {}).get(
+                            "spatial_resolution", None
+                        ),
+                    },
+                    alias=feature["aliases"],
+                )
+                # Append
+                # TODO: Hackish way to determine that the feature is not a qualifier
+                if feature.get("qualifies", None):
+                    if len(feature["qualifies"]) == 0:
+                        outputs.append(output)
+                        # Qualifier output for qualifying features
+                    elif len(feature["qualifies"]) > 0:
+                        qualifier_output = dict(
+                            name=feature["name"],
+                            display_name=feature["display_name"],
+                            description=feature["description"],
+                            # Gross conversion between the two output types.
+                            type=(
+                                "str"
+                                if feature["feature_type"] == "string"
+                                else "binary"
+                                if feature["feature_type"] == "boolean"
+                                else feature["feature_type"]
+                            ),
+                            unit=feature["units"],
+                            unit_description=feature["units_description"],
+                            ontologies={},
+                            related_features=feature["qualifies"],
+                        )
+                        # Append to qualifier outputs
+                        qualifier_outputs.append(qualifier_output)
+                else:
+                    outputs.append(output)
+
+            # Qualifier_outputs
+            for date in context["annotations"]["annotations"]["date"]:
+                if date["primary_date"]:
+                    qualifier_output = dict(
+                        name=date["name"],
+                        display_name=date["display_name"],
+                        description=date["description"],
+                        type="datetime",
+                        unit=date.get("units", None),
+                        unit_description=date.get("units_description", None),
+                        ontologies={},
+                        related_features=feature_names,
+                        # Extra field (Schema allows extras)
+                        qualifier_role="breakdown",
+                    )
+                    # Append
+                    qualifier_outputs.append(qualifier_output)
+
+            # TODO potentially update description dynamically if present in annotations
+            for geo_str in ["country", "admin1", "admin2", "admin3", "lat", "lng"]:
+                qualifier_output = dict(
+                    name=geo_str,
+                    display_name=geo_str,
+                    description="location",
+                    type=geo_str,
+                    unit=None,
+                    unit_description=None,
+                    ontologies={},
+                    related_features=feature_names,
+                    # Extra field (Schema allows extras)
+                    qualifier_role="breakdown",
+                )
+                # Append
+                qualifier_outputs.append(qualifier_output)
+
+        response = {
+            "id": uuid,
+            "name": context["dataset"]["name"],
+            "description": context["dataset"]["description"],
+            "maintainer": context["dataset"]["maintainer"],
+            "outputs": outputs,
+            "qualifier_outputs": qualifier_outputs,
+            "feature_names": feature_names,
+            "published": True,
+        }
+
+        schema = IndicatorSchema.IndicatorMetadataSchema.parse_obj(response)
+
+        update_indicator(schema)

--- a/api/src/settings.py
+++ b/api/src/settings.py
@@ -42,7 +42,8 @@ class Settings(BaseSettings):
     PLUGINS: Dict[str, str] = {
         # "my_plugin": "plugin_module.MyPlugin",  # Where plugin_module.MyPlugin is an importable dotted path and MyPlugin
         # is a subclass of utils.PluginInterface
-        # "causemos": "src.plugins.causemos.CausemosPlugin",
+        "causemos": "src.plugins.causemos.CausemosPlugin",
+        "sync": "src.plugins.sync.SyncPlugin",
         "logger": "src.plugins.logging.LoggingPlugin",
     }
 

--- a/tasks/tasks/elwood_processors.py
+++ b/tasks/tasks/elwood_processors.py
@@ -231,7 +231,7 @@ def run_elwood(context, filename=None, on_success_endpoint=None):
         )
         # Append
         # TODO: Hackish way to determine that the feature is not a qualifier
-        if feature["qualifies"]:
+        if feature.get("qualifies", None):
             if len(feature["qualifies"]) == 0:
                 outputs.append(output)
                 # Qualifier output for qualifying features
@@ -255,6 +255,9 @@ def run_elwood(context, filename=None, on_success_endpoint=None):
                 )
                 # Append to qualifier outputs
                 qualifier_outputs.append(qualifier_output)
+
+        else:
+            outputs.append(output)
 
     # Qualifier_outputs
     for date in context["annotations"]["annotations"]["date"]:

--- a/ui/client/datasets/Flows.js
+++ b/ui/client/datasets/Flows.js
@@ -92,6 +92,7 @@ const BasicRegistrationFlow = {
       jobs: [
         {
           id: 'elwood_processors.run_elwood',
+          send_context: true,
           handler: async ({result, annotations, setAnnotations, datasetInfo, setDatasetInfo, ...extra}) => {
             const updatedDataset = {
               ...datasetInfo,


### PR DESCRIPTION
This syncs the annotations and indicators on publish. This also fixes the issue where the indicator outputs are not updated from the annotations and gives us a job we can run on prior uuids to restore their outputs.