### PR TITLE
Document Explorer Column Sorting

### DIFF
--- a/api/src/documents.py
+++ b/api/src/documents.py
@@ -286,7 +286,7 @@ def format_document(doc):
 def latest_documents(
     scroll_id: Optional[str] = None,
     size: int = 10,
-    sort_by: str = Query("uploaded_at", description="Field to sort by"),
+    sort_by: str = Query("creation_date", description="Field to sort by"),
     order: str = Query("desc", description="Order to sort by")
 ):
     """

--- a/ui/client/documents/ParagraphTile.js
+++ b/ui/client/documents/ParagraphTile.js
@@ -1,0 +1,122 @@
+import React from 'react';
+
+import Typography from '@material-ui/core/Typography';
+import { withStyles } from '@material-ui/core/styles';
+
+import Chip from '@material-ui/core/Chip';
+import LinearProgress from '@material-ui/core/LinearProgress';
+
+import { calculateHighlightTargets } from './utils';
+
+export const ConfidenceBar = withStyles(() => ({
+  root: {
+    height: 15,
+  },
+  colorPrimary: {
+    border: '1px solid gray',
+    backgroundColor: 'transparent',
+    background: 'repeating-linear-gradient( -45deg, gray, gray 1px, white 1px, white 4px )'
+  },
+  bar: {
+    backgroundColor: '#00cd00',
+  },
+}))(LinearProgress);
+
+export const ParagraphTile = withStyles(() => ({
+  root: {
+    padding: '0.5rem 1.5rem',
+    margin: '0.75rem 0',
+    border: '1px solid #B2dfee',
+    borderRadius: 2,
+    background: '#f9f9f9',
+    boxShadow: '4px 4px 8px 0px #9a999969',
+    cursor: 'pointer',
+    '& dl > div': { display: 'flex' },
+    '& dd': { margin: 0 }
+  },
+  squareChip: {
+    borderRadius: 0,
+    background: '#e7e6e6',
+    marginRight: '0.75rem'
+  },
+  chipLabel: {
+    fontWeight: 'bold',
+    width: '4rem',
+    display: 'flex',
+    justifyContent: 'center'
+  }
+}))(({
+  classes, paragraph, highlights = null, query, onClick
+}) => {
+  const handleClick = () => onClick(paragraph);
+
+  return (
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div
+      className={classes.root}
+      onClick={handleClick}
+    >
+      <Typography
+        variant="body1"
+        component="div"
+      >
+
+        <dl>
+          <div style={{ alignItems: 'center', marginBottom: '1rem' }}>
+            <dt>
+              <Chip classes={{ root: classes.squareChip, label: classes.chipLabel }} label="ID" />
+            </dt>
+            <dd>{paragraph.id}</dd>
+          </div>
+
+          <div style={{ alignItems: 'center', marginBottom: '1rem' }}>
+            <dt>
+              <Chip classes={{ root: classes.squareChip, label: classes.chipLabel }} label="Title" />
+            </dt>
+            <dd>{paragraph.parent_document.title || 'No Title Available'}</dd>
+          </div>
+
+          {paragraph.parent_document.publisher && (
+            <div style={{ alignItems: 'center', marginBottom: '1rem' }}>
+              <dt>
+                <Chip classes={{ root: classes.squareChip, label: classes.chipLabel }} label="Publisher" />
+              </dt>
+              <dd>{paragraph.parent_document.publisher}</dd>
+            </div>
+          )}
+
+          <div>
+            <dt>
+              <Chip classes={{ root: classes.squareChip, label: classes.chipLabel }} label="text" />
+            </dt>
+            <dd>{(highlights || calculateHighlightTargets(paragraph.text, query))
+              .map((partInfo, idx) => (
+                <span
+                  key={idx}
+                  style={partInfo.highlight
+                    ? { fontWeight: 'bold', background: 'yellow' }
+                    : {}}
+                >
+                  {partInfo.text}
+                </span>
+              ))}
+            </dd>
+          </div>
+        </dl>
+
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <Chip classes={{ root: classes.squareChip, label: classes.chipLabel }} label="Hit%" />
+          <div style={{ display: 'block', width: '8rem' }}>
+            <ConfidenceBar
+              value={Math.sqrt(paragraph?.metadata?.match_score || 0) * 100}
+              variant="determinate"
+            />
+          </div>
+        </div>
+      </Typography>
+
+      <br />
+    </div>
+  );
+});

--- a/ui/client/documents/ViewDocumentDialog.js
+++ b/ui/client/documents/ViewDocumentDialog.js
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+
+import axios from 'axios';
+
+import CircularProgress from '@material-ui/core/CircularProgress';
+import isEmpty from 'lodash/isEmpty';
+import startCase from 'lodash/startCase';
+
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Divider from '@material-ui/core/Divider';
+
+const fetchDocumentFullText = async (documentId) => {
+  // paragraph id format: documentId-<paragraphIndex>
+  const url = `/api/dojo/documents/${documentId}/paragraphs?size=200`;
+
+  const response = await axios.get(url);
+  return response.data.paragraphs;
+};
+
+/**
+ *
+ **/
+export const ViewDocumentDialog = ({ doc, onClose }) => {
+  const document = doc || {};
+  const [documentText, setDocumentText] = useState(null);
+  const [documentTextLoading, setDocumentTextLoading] = useState(null);
+
+  useEffect(() => {
+    if (!doc?.id) {
+      return;
+    }
+
+    setDocumentTextLoading(true);
+
+    fetchDocumentFullText(doc.id)
+      .then((response) => {
+        setDocumentText(response);
+      })
+      .finally(() => setDocumentTextLoading(false));
+  }, [doc]);
+
+  return (
+    <Dialog
+      open={Boolean(doc)}
+      onClose={onClose}
+      maxWidth="md"
+    >
+      <DialogTitle style={{ paddingBottom: 1 }}>
+        {document.title}
+      </DialogTitle>
+
+      <Divider
+        variant="fullWidth"
+        style={{ margin: '0.5rem 0' }}
+      />
+
+      <DialogContent>
+        {!isEmpty(doc) && (
+          <dl>
+            {['publisher', 'creation_date', 'type', 'original_language',
+              'classification', 'producer', 'stated_genre', 'id']
+              .map((item) => (document[item] ? (
+                <div key={item}>
+                  <dt>{startCase(item)}</dt>
+                  <dd>{document[item]}</dd>
+                </div>
+              ) : null))}
+          </dl>
+        )}
+
+        {documentTextLoading ? (
+          <CircularProgress />
+        ) : documentText?.length ? (
+          <div>
+            <p>Full Text</p>
+            {documentText.map((paragraph) => Boolean(paragraph) && (
+            <DialogContentText key={paragraph.id}>
+              {paragraph.text}
+            </DialogContentText>
+            ))}
+            {documentText.length > 200 && (
+              <p>Document continues. Truncated to 200 lines.</p>
+            )}
+          </div>
+        ) : (
+          <p>Document only contains metadata fields. Does not have text contents.</p>
+        )}
+
+      </DialogContent>
+
+    </Dialog>
+  );
+};

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -137,7 +137,7 @@ const ViewDocumentsGrid = withStyles(() => ({
       } else {
         try {
           const response = await axios.get(
-            `/api/dojo/documents/latest?size=10&sort_by=${column}&order=${order}${scrollIdRef.current ? `&scroll_id=${scrollIdRef.current}` : ''}`
+            `/api/dojo/documents?size=10&sort_by=${column}&order=${order}${scrollIdRef.current ? `&scroll_id=${scrollIdRef.current}` : ''}`
           );
 
           const { data } = response;

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -11,29 +11,20 @@ import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 
 import LinearProgress from '@material-ui/core/LinearProgress';
-import CircularProgress from '@material-ui/core/CircularProgress';
 import CancelIcon from '@material-ui/icons/Cancel';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import TextField from '@material-ui/core/TextField';
-import Chip from '@material-ui/core/Chip';
-import isEmpty from 'lodash/isEmpty';
-import startCase from 'lodash/startCase';
 import map from 'lodash/map';
 import get from 'lodash/get';
 
 import Container from '@material-ui/core/Container';
-import Dialog from '@material-ui/core/Dialog';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
-import Divider from '@material-ui/core/Divider';
 
 import { Link as RouteLink } from 'react-router-dom';
 
-import { calculateHighlightTargets } from "./utils";
-
 import ExpandableDataGridCell from "../components/ExpandableDataGridCell";
+import { ViewDocumentDialog } from './ViewDocumentDialog';
+import { ParagraphTile } from './ParagraphTile';
 
 const expandableCell = ({ value, colDef }) => (
     <ExpandableDataGridCell
@@ -42,22 +33,8 @@ const expandableCell = ({ value, colDef }) => (
     />
 );
 
-export const ConfidenceBar = withStyles((theme) => ({
-  root: {
-    height: 15,
-  },
-  colorPrimary: {
-    border: '1px solid gray',
-    backgroundColor: 'transparent',
-    background: 'repeating-linear-gradient( -45deg, gray, gray 1px, white 1px, white 4px )'
-  },
-  bar: {
-    backgroundColor: '#00cd00',
-  },
-}))(LinearProgress);
-
-const semanticSearchParagraphs = async(query) => {
-  let url = `/api/dojo/paragraphs/search?query=${query}&size=40`;
+const semanticSearchParagraphs = async (query) => {
+  const url = `/api/dojo/paragraphs/search?query=${query}&size=40`;
   const response = await axios.get(url);
   return response.data;
 };
@@ -70,74 +47,6 @@ const semanticSearchParagraphs = async(query) => {
 const fetchDocument = async (docId) => {
   const response = await axios.get(`/api/dojo/documents/${docId}`);
   return response.data;
-};
-
-const fetchDocumentFullText = async (documentId) => {
-  // paragraph id format: documentId-<paragraphIndex>
-  const url = `/api/dojo/documents/${documentId}/paragraphs?size=200`;
-
-  const response = await axios.get(url);
-  return response.data.paragraphs;
-};
-
-
-/**
- * Fetches ALL paragraphs in DB until there's no more scroll ID
- * or the max limit of items is reached.
- * Logic copies from ViewFeatures.js, although we have different requirements here.
- * Only used on experimental paragraph listings.
- **/
-const fetchParagraphs = async (
-  setParagraphs, setSearchLoading, setParagraphsError, scrollId
-) => {
-  setSearchLoading(true);
-
-  let url = `/api/dojo/paragraphs`;
-  if (scrollId) {
-    url += `?scroll_id=${scrollId}`;
-  }
-
-  const paragraphsRequest = axios.get(url).then(
-    (response) => {
-      const data = response.data;
-      return data;
-    }
-  );
-
-  let preparedParagraphs = null;
-  let hitCountThreshold = false;
-
-  preparedParagraphs = paragraphsRequest.then((paragraphsData) => {
-
-    setParagraphs((prev) => {
-
-      // TODO Lets fetch max 100 paragraphs for now
-      if (prev.length > 100) {
-        hitCountThreshold = true;
-      }
-
-      return !scrollId ? paragraphsData.results : prev.concat(paragraphsData.results);
-    });
-
-    return [paragraphsData.scroll_id, paragraphsData.results];
-  });
-
-  preparedParagraphs.then(([ newScrollId, results ]) => {
-
-    // when there's no scroll id, we've hit the end of the results
-    if (newScrollId && !hitCountThreshold) {
-      // if we get a scroll id back, there are more results
-      // so call fetchModels again to fetch the next set
-      fetchParagraphs(setParagraphs, setSearchLoading, setParagraphsError, newScrollId);
-    } else {
-      setSearchLoading(false);
-    }
-  });
-
-  preparedParagraphs.catch((error) => {
-    console.log('error:', error);
-    setParagraphsError(true);
-  });
 };
 
 /**
@@ -159,8 +68,8 @@ function CustomLoadingOverlay() {
  **/
 const documentColumns = [
   {
-    field: 'id',
-    headerName: 'ID',
+    field: 'creation_date',
+    headerName: 'Creation Date',
     minWidth: 200,
   },
   {
@@ -182,182 +91,7 @@ const documentColumns = [
 ];
 
 /**
- *
- **/
-export const ViewDocumentDialog = ({doc, onClose}) => {
-
-  const document = doc || {};
-  const [documentText, setDocumentText] = useState(null);
-  const [documentTextLoading, setDocumentTextLoading] = useState(null);
-
-  useEffect(() => {
-
-    if(!doc?.id) {
-      return;
-    }
-
-    setDocumentTextLoading(true);
-
-    fetchDocumentFullText(doc.id)
-      .then(response => {
-        setDocumentText(response);
-      })
-      .finally(() => setDocumentTextLoading(false));
-
-  }, [doc]);
-
-
-  return (
-    <Dialog
-      open={Boolean(doc)}
-      onClose={onClose}
-      maxWidth="md"
-    >
-      <DialogTitle style={{paddingBottom: 1}}>
-        {document.title}
-      </DialogTitle>
-
-      <Divider
-        variant="fullWidth"
-        style={{margin: "0.5rem 0"}}
-      />
-
-      <DialogContent>
-        {!isEmpty(doc) && (
-          <dl>
-            {["publisher", "creation_date", "type", "original_language",
-              "classification", "producer", "stated_genre"]
-             .map((item, idx) => document[item] ? (
-            <div>
-              <dt>{startCase(item)}</dt>
-              <dd>{document[item]}</dd>
-            </div>
-          ) : null)}
-        </dl>
-        )}
-
-        {documentTextLoading ? (
-          <CircularProgress />
-        ) : documentText?.length ? (
-          <div>
-            <p>Full Text</p>
-              {documentText.map(paragraph => Boolean(paragraph) && (
-                <DialogContentText key={paragraph.id}>
-                  {paragraph.text}
-                </DialogContentText>
-              ))}
-            {documentText.length > 200 && (
-              <p>Document continues. Truncated to 200 lines.</p>
-            )}
-          </div>
-        ) : (
-          <p>Document only contains metadata fields. Does not have text contents.</p>
-        )}
-
-      </DialogContent>
-
-    </Dialog>
-  );
-
-};
-
-export const ParagraphTile = withStyles((theme) => ({
-  root: {
-    padding: "0.5rem 1.5rem",
-    margin: "0.75rem 0",
-    border: "1px solid #B2dfee",
-    borderRadius: 2,
-    background: "#f9f9f9",
-    boxShadow: "4px 4px 8px 0px #9a999969",
-    cursor: "pointer",
-    ["& dl > div"]: {display: "flex", // alignItems: "center"
-                    },
-    ["& dd"]: {margin: 0}
-  },
-  squareChip: {
-    borderRadius: 0,
-    background: "#e7e6e6",
-    marginRight: "0.75rem"
-  },
-  chipLabel: {
-    fontWeight: "bold",
-    width: "4rem",
-    display: "flex",
-    justifyContent: "center"
-  }
-}))(({classes, paragraph, highlights=null, query, onClick}) => {
-
-  const handleClick = () => onClick(paragraph);
-
-  return (
-    <div
-      className={classes.root}
-      onClick={handleClick}
-    >
-      <Typography
-        variant="body1"
-        component="div">
-
-        <dl>
-          <div style={{alignItems: "center", marginBottom: "1rem"}}>
-            <dt>
-              <Chip classes={{root: classes.squareChip, label: classes.chipLabel}} label="ID" />
-            </dt>
-            <dd>{paragraph.id}</dd>
-          </div>
-
-          <div style={{alignItems: "center", marginBottom: "1rem"}}>
-            <dt>
-              <Chip classes={{root: classes.squareChip, label: classes.chipLabel}} label="Title" />
-            </dt>
-            <dd>{paragraph.parent_document.title || "No Title Available"}</dd>
-          </div>
-
-          {paragraph.parent_document.publisher && (
-            <div style={{alignItems: "center", marginBottom: "1rem"}}>
-              <dt>
-                <Chip classes={{root: classes.squareChip, label: classes.chipLabel}} label="Publisher" />
-              </dt>
-              <dd>{paragraph.parent_document.publisher}</dd>
-            </div>
-          )}
-
-          <div>
-            <dt>
-              <Chip classes={{root: classes.squareChip, label: classes.chipLabel}} label="text" />
-            </dt>
-            <dd>{(highlights || calculateHighlightTargets(paragraph.text, query))
-                 .map((partInfo, idx) => (
-                   <span
-                     key={idx}
-                     style={partInfo.highlight ?
-                            {fontWeight: 'bold', background: 'yellow'} :
-                            {}}
-                   >
-                     {partInfo.text}
-                   </span>
-                 ))}</dd>
-          </div>
-        </dl>
-
-        <div style={{display: "flex", alignItems: "center"}}>
-          <Chip classes={{root: classes.squareChip, label: classes.chipLabel}} label="Hit%" />
-          <div style={{display: "block", width: "8rem"}}>
-            <ConfidenceBar
-              value={Math.sqrt(paragraph?.metadata?.match_score || 0) * 100}
-              variant='determinate'
-            />
-          </div>
-        </div>
-      </Typography>
-
-      <br />
-    </div>
-  );
-});
-
-/**
- *
+ * The root component for the document browser, rendering the page Container, DataGrid, and Dialog
  */
 const ViewDocumentsGrid = withStyles(() => ({
   root: {
@@ -379,6 +113,8 @@ const ViewDocumentsGrid = withStyles(() => ({
   const scrollIdRef = useRef(null);
   const cachedDocumentsRef = useRef({});
 
+  // controlled grid page state so that we can manually reset it to 0 when the sort changes
+  const [gridPage, setGridPage] = useState(0);
   const [documents, setDocuments] = useState(null);
   const [documentsError, setDocumentsError] = useState(null);
   const [documentsLoading, setDocumentsLoading] = useState(false);
@@ -386,7 +122,7 @@ const ViewDocumentsGrid = withStyles(() => ({
   const fetchData = useCallback(
     // we use DataGrid's page index to maintain a cache for what DG should display
     // on each page of results. The API just uses a scroll_id and has no notion of this page
-    async (page, column = 'uploaded_at', order = 'desc') => {
+    async (page, column = 'creation_date', order = 'desc') => {
       setDocumentsLoading(true);
       setDocumentsError(null);
       // clear documents when loading so that we don't display the previous page
@@ -396,6 +132,7 @@ const ViewDocumentsGrid = withStyles(() => ({
       // check if data for the page is already in the cache
       if (cachedDocumentsRef.current[page]) {
         setDocuments(cachedDocumentsRef.current[page]);
+        setGridPage(page);
         setDocumentsLoading(false);
       } else {
         try {
@@ -413,8 +150,9 @@ const ViewDocumentsGrid = withStyles(() => ({
             ...cachedDocumentsRef.current,
             [page]: data,
           };
-          console.log('THIS IS THE NEW DATA', data)
+
           setDocuments(data);
+          setGridPage(page);
         } catch (error) {
           setDocumentsError(error);
         } finally {
@@ -435,14 +173,16 @@ const ViewDocumentsGrid = withStyles(() => ({
   const totalRowsCount = Number(documents?.hits)
     || Number(cachedDocumentsRef.current[0]?.hits) || 0;
 
-  const handlePageChange = (params) => {
-    fetchData(params);
+  const handlePageChange = (newPage) => {
+    fetchData(newPage);
   };
 
   const handleSortChange = (newSort) => {
-    console.log('THIS is newSort', newSort);
+    // clear the scrollId so the API doesn't think we are continuing a request
     scrollIdRef.current = null;
+    // clear the cache so we don't try to reload previous results (that have a different sort)
     cachedDocumentsRef.current = {};
+    // fetch the data & load it into the grid
     fetchData(0, newSort[0].field, newSort[0].sort);
   };
 
@@ -633,6 +373,7 @@ const ViewDocumentsGrid = withStyles(() => ({
               <br />
 
               <DataGrid
+                page={gridPage}
                 autoHeight
                 components={{
                   LoadingOverlay: CustomLoadingOverlay

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -22,15 +22,15 @@ import Container from '@material-ui/core/Container';
 
 import { Link as RouteLink } from 'react-router-dom';
 
-import ExpandableDataGridCell from "../components/ExpandableDataGridCell";
+import ExpandableDataGridCell from '../components/ExpandableDataGridCell';
 import { ViewDocumentDialog } from './ViewDocumentDialog';
 import { ParagraphTile } from './ParagraphTile';
 
 const expandableCell = ({ value, colDef }) => (
-    <ExpandableDataGridCell
-      value={value}
-      width={colDef.computedWidth}
-    />
+  <ExpandableDataGridCell
+    value={value}
+    width={colDef.computedWidth}
+  />
 );
 
 const semanticSearchParagraphs = async (query) => {
@@ -98,12 +98,12 @@ const ViewDocumentsGrid = withStyles(() => ({
     flex: 1,
     display: 'flex',
     flexDirection: 'column',
-    padding: "2rem",
-    marginTop: "1rem"
+    padding: '2rem',
+    marginTop: '1rem'
   },
   aboveTableWrapper: {
     display: 'flex',
-    maxWidth: "100vw",
+    maxWidth: '100vw',
     justifyContent: 'center',
     alignItems: 'center',
     marginBottom: '1rem',
@@ -218,7 +218,7 @@ const ViewDocumentsGrid = withStyles(() => ({
         const allDocPromises = allParagraphs.map((paragraph, idx) => {
           const documentPromise = fetchDocument(paragraph.document_id);
 
-          documentPromise.then(doc => {
+          documentPromise.then((doc) => {
             allParagraphs[idx].parent_document = doc;
           });
 
@@ -228,23 +228,21 @@ const ViewDocumentsGrid = withStyles(() => ({
         Promise.all(allDocPromises).then(() => {
           setDocParagraphResults(allParagraphs);
 
-          if (process.env.DISABLE_SEMANTIC_HIGHLIGHT !== "true") {
+          if (process.env.DISABLE_SEMANTIC_HIGHLIGHT !== 'true') {
             // fetch all highlights for results
             const matches = map(allParagraphs, 'text');
             const query = searchTerm;
 
-            let url = `/api/dojo/paragraphs/highlight`;
+            const url = '/api/dojo/paragraphs/highlight';
 
             return axios.post(url, {
               query,
               matches
             }).then((response) => {
               setHighlights(response.data.highlights);
-              return;
             });
-          } else {
-            console.info("Semantic Highlighter disabled.");
           }
+          console.info('Semantic Highlighter disabled.');
         });
       })
       .finally(() => {
@@ -311,7 +309,7 @@ const ViewDocumentsGrid = withStyles(() => ({
         <>
           <div className={classes.aboveTableWrapper}>
             <TextField
-              style={{ width: "100%", maxWidth: "60rem" }}
+              style={{ width: '100%', maxWidth: '60rem' }}
               label="Enter query to perform Semantic Search through Documents"
               variant="outlined"
               value={searchTermValue}
@@ -336,7 +334,7 @@ const ViewDocumentsGrid = withStyles(() => ({
               </Typography>
 
               {searchLoading && (
-                <LinearProgress style={{ width: "90%" }} />
+                <LinearProgress style={{ width: '90%' }} />
               )}
 
               {docParagraphResults.map((p, index) => (

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -137,7 +137,7 @@ const ViewDocumentsGrid = withStyles(() => ({
       } else {
         try {
           const response = await axios.get(
-            `/api/dojo/documents?size=10&sort_by=${column}&order=${order}${scrollIdRef.current ? `&scroll_id=${scrollIdRef.current}` : ''}`
+            `/api/dojo/documents?size=100&sort_by=${column}&order=${order}${scrollIdRef.current ? `&scroll_id=${scrollIdRef.current}` : ''}`
           );
 
           const { data } = response;
@@ -371,6 +371,7 @@ const ViewDocumentsGrid = withStyles(() => ({
               <br />
 
               <DataGrid
+                sortingOrder={['desc', 'asc']}
                 page={gridPage}
                 autoHeight
                 components={{
@@ -380,13 +381,14 @@ const ViewDocumentsGrid = withStyles(() => ({
                 loading={documentsLoading || searchLoading}
                 columns={displayableColumns}
                 rows={documents?.results || []}
-                pageSize={10}
+                pageSize={100}
                 onPageChange={handlePageChange}
                 paginationMode="server"
                 rowCount={totalRowsCount}
                 disableColumnFilter
                 sortingMode="server"
                 onSortModelChange={handleSortChange}
+                disableColumnMenu
               />
             </>
           )}

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -122,7 +122,7 @@ const ViewDocumentsGrid = withStyles(() => ({
   const fetchData = useCallback(
     // we use DataGrid's page index to maintain a cache for what DG should display
     // on each page of results. The API just uses a scroll_id and has no notion of this page
-    async (page, column = 'creation_date', order = 'desc') => {
+    async ({ page, column = 'creation_date', order = 'desc' }) => {
       setDocumentsLoading(true);
       setDocumentsError(null);
       // clear documents when loading so that we don't display the previous page
@@ -165,7 +165,7 @@ const ViewDocumentsGrid = withStyles(() => ({
   // do the initial fetch to load our first page
   useEffect(() => {
     // fetchData only references refs and state setters, so this should only be called once
-    fetchData(0);
+    fetchData({ page: 0 });
   }, [fetchData]);
 
   // fetch the rows out of the cache for page 0 so that we maintain it even when we clear
@@ -174,7 +174,7 @@ const ViewDocumentsGrid = withStyles(() => ({
     || Number(cachedDocumentsRef.current[0]?.hits) || 0;
 
   const handlePageChange = (newPage) => {
-    fetchData(newPage);
+    fetchData({ page: newPage });
   };
 
   const handleSortChange = (newSort) => {
@@ -183,7 +183,7 @@ const ViewDocumentsGrid = withStyles(() => ({
     // clear the cache so we don't try to reload previous results (that have a different sort)
     cachedDocumentsRef.current = {};
     // fetch the data & load it into the grid
-    fetchData(0, newSort[0].field, newSort[0].sort);
+    fetchData({ page: 0, column: newSort[0].field, order: newSort[0].sort });
   };
 
   const [searchTerm, setSearchTerm] = useState('');

--- a/ui/stories/ParagraphTile.stories.js
+++ b/ui/stories/ParagraphTile.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Field, Formik, Form } from 'formik';
 import identity from 'lodash/identity';
 
-import { ParagraphTile } from '../client/documents';
+import { ParagraphTile } from '../client/documents/ParagraphTile';
 
 export default {
   title: 'Document Explorer/Paragraph Tile',

--- a/ui/stories/ViewDocumentDialog.stories.js
+++ b/ui/stories/ViewDocumentDialog.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Field, Formik, Form } from 'formik';
 import identity from 'lodash/identity';
 
-import { ViewDocumentDialog } from '../client/documents';
+import { ViewDocumentDialog } from '../client/documents/ViewDocumentDialog';
 
 export default {
   title: 'Document Explorer/ViewDocument Dialog',


### PR DESCRIPTION
With the new server-mode pagination, the document explorer sorting was no longer working. This PR gets it working again with changes to the UI and API code. 

The Document Explorer <DataGrid> component now has custom handling for when the sort changes, which hooks into the same data fetching logic as the pagination. We now, however, pass along sort_by and order parameters to `GET /documents`.

The `GET /documents` endpoint now receives these optional `sort_by` and `order` parameters, checks if they are one of the valid fields, and if so, will return the sorted list of documents as requested. 

I also broke `documents/index.js` into several files and did some general cleanup for code organization/readability, as it was starting to get fairly long and confusing to work in. 