### PR TITLE
UI Dataset Register: Clear `time_format` for `date_type=epoch`

### DIFF
--- a/ui/client/datasets/annotations/dataOUT.js
+++ b/ui/client/datasets/annotations/dataOUT.js
@@ -125,6 +125,13 @@ function formatDateAnnotationOUT(localAnnotation, outgoingAnnotationBase) {
     genDateMultiPartMemberAnnotation(localAnnotation, outgoingAnnotation)
       .forEach((item) => { collectedOutgoingAnnotations.push(item); });
   }
+
+  if (localAnnotation.date_type == 'epoch') {
+    // fix for cartwrights/geotimeclassify inserting time_format for epochs, which is not needed
+    // also helps with csv dictionary annotation
+    outgoingAnnotation.time_format = '';
+  }
+
   collectedOutgoingAnnotations.push(outgoingAnnotation);
 
   return collectedOutgoingAnnotations;

--- a/ui/client/datasets/annotations/dataOUT.test.js
+++ b/ui/client/datasets/annotations/dataOUT.test.js
@@ -1056,8 +1056,7 @@ describe('formatAnnotationsOUT', () => {
       ]);
   });
 
-
-test('regular admin0 geo is forced to resolve_to_gadm=true', () => {
+  test('regular admin0 geo is forced to resolve_to_gadm=true', () => {
     const input = {
       'admin0': {
         aliases: [],
@@ -1086,7 +1085,6 @@ test('regular admin0 geo is forced to resolve_to_gadm=true', () => {
         time_format: '',
         'date.multi-column': false,
 
-        multiPartBase: 'admin0',
         annotated: true
       }
     };
@@ -1109,6 +1107,61 @@ test('regular admin0 geo is forced to resolve_to_gadm=true', () => {
           qualifies: [],
           qualifierrole: 'breakdown',
           resolve_to_gadm: true
+        },
+      ]);
+  });
+
+test('date format is removed for timestamp/epoch fields', () => {
+    const input = {
+      'timestamp': {
+        aliases: [],
+
+        category: 'time',
+        display_name: 'my epoch ts',
+        description: 'date format is not used so it will be removed',
+
+        isQualifies: false,
+        qualifierrole: 'breakdown',
+        qualifies: [],
+
+        geo_type: '',
+        primary: true,
+        gadm_level: '',
+        'geo.coordinate-pair': false,
+
+        'geo.multi-column': false,
+
+        'geo.multi-column.admin0': '',
+        'geo.multi-column.admin1': '',
+        'geo.multi-column.admin2': '',
+        'geo.multi-column.admin3': '',
+
+        date_type: 'epoch',
+        time_format: 'unix_time', // what helped us discover this bug; cartwrights format annotaition
+        'date.multi-column': false,
+
+        annotated: true
+      }
+    };
+
+    const output = formatAnnotationsOUT(input);
+
+    expect(output.date)
+      .toEqual([
+        {
+          name: 'timestamp',
+          type: 'date',
+
+          date_type: 'epoch',
+          time_format: '',
+
+          description: 'date format is not used so it will be removed',
+          display_name: 'my epoch ts',
+          primary_date: true,
+
+          aliases: {},
+          qualifies: [],
+          qualifierrole: 'breakdown'
         },
       ]);
   });


### PR DESCRIPTION
cartwright was adding an invalid value there (inferred value broke registration), which isnt used but somehow was confusing elwood. Fixed and added ui unit test to confirm it.

This was what UI wsa loading as default value:

![Screenshot from 2023-05-18 10-29-26](https://github.com/jataware/dojo-stack/assets/1967061/6517a30d-89c1-48eb-b334-87cf08cae80c)

Then I proceeded to switch the subcategory to `epoch` (instead of `Date`), but forgot to clear `date format`

when clicking next and running the annotation processing through elwood, we would get:

![Screenshot from 2023-05-18 10-39-45](https://github.com/jataware/dojo-stack/assets/1967061/161a7eac-16b4-47e0-a705-c92c7d1337ef)

Hopefully this isn't a bug anymore after this PR 🎉 