### PR TITLE
Small changes to Document Explorer table

### DIFF
--- a/ui/client/documents/ViewDocumentDialog.js
+++ b/ui/client/documents/ViewDocumentDialog.js
@@ -61,7 +61,7 @@ export const ViewDocumentDialog = ({ doc, onClose }) => {
         {!isEmpty(doc) && (
           <dl>
             {['publisher', 'creation_date', 'type', 'original_language',
-              'classification', 'producer', 'stated_genre', 'id']
+              'classification', 'producer', 'stated_genre', 'id', 'description']
               .map((item) => (document[item] ? (
                 <div key={item}>
                   <dt>{startCase(item)}</dt>

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -4,6 +4,7 @@ import React, {
 
 import axios from 'axios';
 import debounce from 'lodash/debounce';
+import { format } from 'date-fns'
 
 import Button from '@material-ui/core/Button';
 import { GridOverlay, DataGrid } from '@material-ui/data-grid';
@@ -76,6 +77,11 @@ const documentColumns = [
     field: 'uploaded_at',
     headerName: 'Date Uploaded',
     minWidth: 200,
+    renderCell: (params) => {
+      if (params.value) {
+        return <span>{format(params.value, 'yyyy-MM-dd')}</span>;
+      }
+    },
   },
   {
     field: 'publisher',

--- a/ui/client/documents/index.js
+++ b/ui/client/documents/index.js
@@ -69,13 +69,13 @@ function CustomLoadingOverlay() {
 const documentColumns = [
   {
     field: 'creation_date',
-    headerName: 'Creation Date',
+    headerName: 'Date Created',
     minWidth: 200,
   },
   {
-    field: 'title',
-    headerName: 'Title',
-    flex: 1
+    field: 'uploaded_at',
+    headerName: 'Date Uploaded',
+    minWidth: 200,
   },
   {
     field: 'publisher',
@@ -83,11 +83,11 @@ const documentColumns = [
     width: 200,
   },
   {
-    field: 'description',
-    headerName: 'Description',
-    renderCell: expandableCell,
-    flex: 2
-  }
+    field: 'title',
+    headerName: 'Title',
+    flex: 1,
+    renderCell: expandableCell
+  },
 ];
 
 /**


### PR DESCRIPTION
This updates the following in the Document Explorer table/grid: 

- Removes the Description column from the table and adds description to each document's dialog 
- Adds uploaded_at as a column
- Renames uploaded_at and creation_date to `Date Created` and `Date Uploaded`