### PR TITLE
Store data transformations on annotations object

### DIFF
--- a/api/validation/MetadataSchema.py
+++ b/api/validation/MetadataSchema.py
@@ -174,6 +174,12 @@ class ClipTime(BaseModel):
 
 Transformation = Union[RegridGeo, ScaleTime, ClipGeo, ClipTime]
 
+class Metadata(BaseModel):
+    class Config:
+        extra = Extra.allow
+
+    transformations: Optional[Dict[str, Transformation]]
+
 class AnnotationSchema(BaseModel):
     class Config:
         extra = Extra.allow
@@ -181,9 +187,7 @@ class AnnotationSchema(BaseModel):
     geo: Optional[List[GeoAnnotation]]
     date: Optional[List[DateAnnotation]]
     feature: Optional[List[FeatureAnnotation]]
-    transformations: Optional[Dict[str, Transformation]]
-
 
 class MetaModel(BaseModel):
-    metadata: Optional[Dict[str, Any]] = {}
+    metadata: Optional[Metadata] = None
     annotations: Optional[AnnotationSchema] = None

--- a/api/validation/MetadataSchema.py
+++ b/api/validation/MetadataSchema.py
@@ -1,6 +1,7 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Union
 from enum import Enum
 from pydantic import BaseModel, Field, Extra
+from datetime import date
 
 
 # Metadata Model Used to store annotation data along with any other metadata we may need inside of a dictionary with string keys and any type of data.
@@ -142,6 +143,36 @@ class FeatureAnnotation(BaseModel):
     qualifierrole: Optional[str]
     aliases: Dict[str, str] = {}
 
+# All the data transformations
+class LatLong(BaseModel):
+    lng: float
+    lat: float
+
+class TimeRange(BaseModel):
+    start: date
+    end: date
+
+class RegridGeo(BaseModel):
+    datetime_column: List[str]
+    geo_columns: List[str]
+    scale: float
+    scale_multi: float
+
+class ScaleTime(BaseModel):
+    datetime_bucket: str
+    datetime_column: str
+    geo_columns: List[str]
+    aggregation_function_list: List[str]
+
+class ClipGeo(BaseModel):
+    geo_columns: List[str]
+    map_shapes: List[List[LatLong]]
+
+class ClipTime(BaseModel):
+    time_ranges: List[TimeRange]
+    datetime_column: str
+
+Transformation = Union[RegridGeo, ScaleTime, ClipGeo, ClipTime]
 
 class AnnotationSchema(BaseModel):
     class Config:
@@ -150,6 +181,7 @@ class AnnotationSchema(BaseModel):
     geo: Optional[List[GeoAnnotation]]
     date: Optional[List[DateAnnotation]]
     feature: Optional[List[FeatureAnnotation]]
+    transformations: Optional[Dict[str, Transformation]]
 
 
 class MetaModel(BaseModel):

--- a/ui/client/datasets/DataTransformation/DataTransformation.js
+++ b/ui/client/datasets/DataTransformation/DataTransformation.js
@@ -367,14 +367,17 @@ const DataTransformation = withStyles(() => ({
       }
 
       // If there are transformations, we want to store the data transformation decisions
-      const clonedAnnotations = cloneDeep(annotations.annotations);
+      const clonedMetadata = cloneDeep(annotations.metadata);
       // add all the args that we sent to the elwood jobs and stored in our ref
-      // to our cloned annotations object
-      clonedAnnotations.transformations = transformationsRef.current;
-
+      // to our cloned metadata object
+      clonedMetadata.transformations = transformationsRef.current;
       // and PATCH that to the dataset's annotations
+      // along with the existing annotations so it doesn't overwrite anything
       axios.patch(
-        `/api/dojo/indicators/${datasetInfo.id}/annotations`, { annotations: clonedAnnotations }
+        `/api/dojo/indicators/${datasetInfo.id}/annotations`, {
+          annotations: annotations.annotations,
+          metadata: clonedMetadata
+        }
       ).then(() => {
         // Only handleNext once we've updated the annotations
         handleNext();


### PR DESCRIPTION
This adds the data transformation selections to the annotations object when the user hits `NEXT` on the Transformation step. The data is nested under `transformation` and is identical to the arguments that are sent to kick off the Elwood jobs. Each transformation is keyed under the Elwood job name: `clip_geo`, `regrid_geo`, etc. 

I also added `transformations` to the MetadataSchema under `annotations.transformations`. This can easily be moved if anyone thinks it would make more sense under metadata or under its own top level field. 