### PR TITLE
Added new hybrid search implementation

### DIFF
--- a/api/scripts/hybrid_search.py
+++ b/api/scripts/hybrid_search.py
@@ -78,12 +78,10 @@ QUERIES = [
     hybrid_query_v1,
     keyword_query_v1,
     hybrid_query_v0,
-    # hybrid_query_v2,
+    hybrid_query_v2,
     keyword_query_v3
 ]
 
-# TODO expand so that query is queries (list) and we call all of them if needed
-#      then also receive an additional post_op function that applies some operation to the results of all queries
 def search(query):
 
     # NOTE this is all hacked up but Ok for now; args.size would fail

--- a/api/scripts/hybrid_search.py
+++ b/api/scripts/hybrid_search.py
@@ -42,7 +42,9 @@ from src.feature_queries import (
     semantic_search_query,
     hybrid_query_v1,
     keyword_query_v1,
-    hybrid_query_v0
+    hybrid_query_v0,
+    hybrid_query_v2,
+    keyword_query_v3,
 )
 
 import collections
@@ -61,7 +63,7 @@ parser.add_argument("-q", "--query",
 
 parser.add_argument("-s", "--size",
                     help="es scroll page result size",
-                    type=int, default=10)
+                    type=int, default=100)
 
 
 if __name__ == "__main__":
@@ -69,14 +71,19 @@ if __name__ == "__main__":
     es = Elasticsearch(f"http://{args.es_host}")
     print(es.info())
 
+
 QUERIES = [
     keyword_query_v2,
     semantic_search_query,
     hybrid_query_v1,
     keyword_query_v1,
-    hybrid_query_v0
+    hybrid_query_v0,
+    # hybrid_query_v2,
+    keyword_query_v3
 ]
 
+# TODO expand so that query is queries (list) and we call all of them if needed
+#      then also receive an additional post_op function that applies some operation to the results of all queries
 def search(query):
 
     # NOTE this is all hacked up but Ok for now; args.size would fail
@@ -90,7 +97,6 @@ def search(query):
 pp = pprint.PrettyPrinter(indent=2)
 
 
-# TODO Get targets and sample queries from MITRE
 test_inputs = [
     # {"target_id": "b1a6c625-69a1-4399-b3cb-68cf484826a7-TX.VAL.TRAN.ZS.WT",
     #  "queries": ["TX.VAL.TRAN.ZS.WT", "Transport", "Transport services", "Service for all transport types",
@@ -104,6 +110,16 @@ test_inputs = [
     #              "women enrolled in education programs",
     #              "Education indicators female", "female"]
     #  },
+
+    # TODO add query for rain / drain
+    {
+        "target_id": "8b2f4931-0da0-45b6-88f7-187bc6f36c86-Long term average annual precipitation",
+
+        "queries": [
+            "rain",
+            "drain"
+                ]
+    },
 
     {
         "target_id": "db48c2bb-9080-41d6-a5b9-916c0c6871f1-Amount (Constant USD2017)",
@@ -129,6 +145,7 @@ test_inputs = [
 
 ]
 
+
 def test_one_query(query_dict, target_id, fn):
 
     query = fn(query_dict)
@@ -145,7 +162,6 @@ def test_one_query(query_dict, target_id, fn):
             found_index = index
 
     return found_index, took
-
 
 
 
@@ -170,10 +186,10 @@ def average_values(input_dict):
             if 'took' in prop:
                 took_sum += prop['took']
                 took_count += 1
-                        
+
     index_avg = round(index_sum / index_count)
     took_avg = round(took_sum / took_count)
-    
+
     return {'index_avg': index_avg, 'took_avg': took_avg, 'none_count': index_none_count}
 
 
@@ -188,8 +204,8 @@ def generate_report(results_dict):
     return acc
 
 
-if __name__ == "__main__":
 
+def main_all_queries_report():
     found_indeces = recursive_dict()
 
     for index, test in enumerate(test_inputs):
@@ -210,5 +226,9 @@ if __name__ == "__main__":
     print("\n\n >>>>> Report:")
 
     pp.pprint(report)
+
+
+if __name__ == "__main__":
+    main_all_queries_report()
 
     exit(0)

--- a/api/src/feature_queries.py
+++ b/api/src/feature_queries.py
@@ -1,5 +1,36 @@
 from src.embedder_engine import embedder
 
+def keyword_query_v3(phrase):
+    """
+    """
+    q = {
+        "query": {
+            "bool": {
+                "should": [
+                    {
+                        "match_phrase": {
+                            "name": phrase
+                        }
+                    },
+                    {
+                        "match_phrase": {
+                            "display_name": phrase
+                        }
+                    },
+                    {
+                        "match_phrase": {
+                            "description": phrase
+                        }
+                    }
+                ]
+            }
+        },
+        "_source": {
+            "excludes": "embeddings"
+        }
+    }
+    return q
+
 
 def keyword_query_v2(term):
     q = {
@@ -177,3 +208,17 @@ def hybrid_query_v0(query):
         }
     })
     return features_query
+
+
+def hybrid_query_v2(query):
+    """
+    """
+    embedding = embedder.embed([query])[0]
+
+    keyword_query = keyword_query_v3(query)
+
+    semantic_query = semantic_search_query(query)
+
+    return (keyword_query, semantic_query)
+
+

--- a/api/src/indicators.py
+++ b/api/src/indicators.py
@@ -183,8 +183,6 @@ def semantic_search_features(
 
     first = results["hits"]["hits"][0]
 
-    logger.info(f"First hybrid response:\n{first}")
-
     alternated = format_hybrid_results(results["hits"]["hits"])
 
     return {

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -363,10 +363,7 @@ def group_by_query(data_list):
 
 
 def format_hybrid_results(all_results):
-    grouped = group_by_query(all_results)
-
-    keyword_results, semantic_results = grouped
-
+    keyword_results, semantic_results = group_by_query(all_results)
     alternated = alternate_lists(keyword_results, semantic_results)
 
     return alternated

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -325,7 +325,7 @@ def alternate_lists(list1, list2, id_property=None):
     """
 
     if id_property:
-        list2 = get_unique_items(list1, list2)
+        list2 = get_unique_items(list1, list2, id_property)
     
     # Determine the length of the longest list
     max_length = max(len(list1), len(list2))

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -301,3 +301,42 @@ def add_date_to_dataset(path):
         "qualifies": [],
         "aliases": {},
     }
+
+
+def get_unique_items(list1, list2, id_property="_id"):
+    ids_list1 = set(item[id_property] for item in list1)
+    unique_items = [item for item in list2 if item[id_property] not in ids_list1]
+    return unique_items
+
+
+def alternate_lists(list1, list2, id_property=None):
+    """
+    Given to lists:
+    - a) ["k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8"]
+    - b) ["s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"]
+
+    returns a new list of length max_lenght(a, b) and alternates items
+    stepping by 3. Example output:
+
+    ["k1", "k2", "k3", "s1", "s2", "s3", "k4", "k5", "k6", "s4"]
+
+    If id_property is provided, it is presumed the lists contain dictionaries,
+    and the duplicates are removed by checking the id_property in the dictionary
+    """
+
+    if id_property:
+        list2 = get_unique_items(list1, list2)
+    
+    # Determine the length of the longest list
+    max_length = max(len(list1), len(list2))
+
+    # Create an empty list to hold the final result
+    result = []
+
+    # Iterate over the range from 0 to the max length, stepping by 3
+    for i in range(0, max_length, 3):
+        # Extend result with next three elements from each list if they exist
+        result.extend(list1[i:i+3])
+        result.extend(list2[i:i+3])
+    return result
+

--- a/api/src/utils.py
+++ b/api/src/utils.py
@@ -326,7 +326,7 @@ def alternate_lists(list1, list2, id_property=None):
 
     if id_property:
         list2 = get_unique_items(list1, list2, id_property)
-    
+
     # Determine the length of the longest list
     max_length = max(len(list1), len(list2))
 
@@ -340,3 +340,33 @@ def alternate_lists(list1, list2, id_property=None):
         result.extend(list2[i:i+3])
     return result
 
+
+keyword_query_names = [
+    "keyword_name",
+    "keyword_display_name",
+    "keyword_description"
+]
+
+def group_by_query(data_list):
+    grouped_dict = {
+        "keyword": [],
+        "semantic": [],
+    }
+    for item in data_list:
+        # at least one matched_queries contains keyword element/aspect
+        if any(i in keyword_query_names for i in item.get("matched_queries")):
+            grouped_dict["keyword"].append(item)
+        else:
+            grouped_dict["semantic"].append(item)
+
+    return (grouped_dict["keyword"], grouped_dict["semantic"])
+
+
+def format_hybrid_results(all_results):
+    grouped = group_by_query(all_results)
+
+    keyword_results, semantic_results = grouped
+
+    alternated = alternate_lists(keyword_results, semantic_results)
+
+    return alternated

--- a/api/src/utils_test.py
+++ b/api/src/utils_test.py
@@ -1,0 +1,21 @@
+from src.utils import alternate_lists
+
+def test_alternate_lists__standard():
+
+    list1 = [1,2,3,4,5,6]
+    list2 = [7,8,9,10,11,12]
+
+    output = alternate_lists(list1, list2)
+
+    assert output == [1, 2, 3, 7, 8, 9, 4, 5, 6, 10, 11, 12]
+    assert len(output) == 12
+
+def test_alternate_lists__repeated_items():
+
+    list1 = [{"_id": 1}, {"_id": 2}, {"_id": 3}, {"_id": 4}, {"_id": 5}, {"_id": 6}]
+    list2 = [{"_id": 7}, {"_id": 8}, {"_id": 9}, {"_id": 1}, {"_id": 2}, {"_id": 3}]
+
+    output = alternate_lists(list1, list2, id_property="_id")
+
+    assert output == [{"_id": 1}, {"_id": 2}, {"_id": 3}, {"_id": 7}, {"_id": 8}, {"_id": 9}, {"_id": 4}, {"_id": 5}, {"_id": 6}]
+    assert len(output) == 9

--- a/api/src/utils_test.py
+++ b/api/src/utils_test.py
@@ -1,4 +1,6 @@
-from src.utils import alternate_lists
+import pytest
+from src.utils import alternate_lists, format_hybrid_results
+
 
 def test_alternate_lists__standard():
 
@@ -19,3 +21,30 @@ def test_alternate_lists__repeated_items():
 
     assert output == [{"_id": 1}, {"_id": 2}, {"_id": 3}, {"_id": 7}, {"_id": 8}, {"_id": 9}, {"_id": 4}, {"_id": 5}, {"_id": 6}]
     assert len(output) == 9
+
+
+@pytest.mark.unit
+def test_format_hybrid_results__simple():
+    my_list = [
+        {"_id": 1,"_source": {"name": "item1"}, "matched_queries": ["semantic_search"]},
+        {"_id": 2,"_source": {"name": "item2"}, "matched_queries": ["semantic_search"]},
+        {"_id": 3,"_source": {"name": "item3"}, "matched_queries": ["keyword_name"]},
+        {"_id": 4,"_source": {"name": "item4"}, "matched_queries": ["keyword_display_name"]},
+        {"_id": 5,"_source": {"name": "item5"}, "matched_queries": ["keyword_description"]},
+        {"_id": 6,"_source": {"name": "item6"}, "matched_queries": ["semantic_search"]},
+        {"_id": 7,"_source": {"name": "item7"}, "matched_queries": ["semantic_search"]},
+        {"_id": 8,"_source": {"name": "item8"}, "matched_queries": ["keyword_display_name"]},
+    ]
+
+    out = format_hybrid_results(my_list)
+
+    assert out == [
+        {"_id": 3,"_source": {"name": "item3"}, "matched_queries": ["keyword_name"]},
+        {"_id": 4,"_source": {"name": "item4"}, "matched_queries": ["keyword_display_name"]},
+        {"_id": 5,"_source": {"name": "item5"}, "matched_queries": ["keyword_description"]},
+        {"_id": 1,"_source": {"name": "item1"}, "matched_queries": ["semantic_search"]},
+        {"_id": 2,"_source": {"name": "item2"}, "matched_queries": ["semantic_search"]},
+        {"_id": 6,"_source": {"name": "item6"}, "matched_queries": ["semantic_search"]},
+        {"_id": 8,"_source": {"name": "item8"}, "matched_queries": ["keyword_display_name"]},
+        {"_id": 7,"_source": {"name": "item7"}, "matched_queries": ["semantic_search"]},
+    ]

--- a/ui/client/components/ViewFeatures.js
+++ b/ui/client/components/ViewFeatures.js
@@ -30,7 +30,7 @@ const MATCH_TYPE = {
 };
 
 /**
- * Maytch % confidence bar
+ * Used in Match % column when searching
  **/
 export const ConfidenceBar = withStyles(() => ({
   root: {

--- a/ui/client/components/ViewFeatures.js
+++ b/ui/client/components/ViewFeatures.js
@@ -364,7 +364,6 @@ const ViewFeatures = withStyles(() => ({
           LoadingOverlay: CustomLoadingOverlay
         }}
         loading={featuresLoading}
-        getRowId={(row) => `${row.owner_dataset.id}-${row.name}`}
         columns={featureColumns}
         rows={features}
       />


### PR DESCRIPTION
New implementation does not use fuzzy matching on the keyword match side, as well as consolidates results of both keyword and semantic on the python server, by alternating results 3 at a time.

How it looks integrated with the UI:
![Screenshot from 2023-06-23 16-18-14](https://github.com/jataware/dojo/assets/1967061/c972815d-2ac8-463d-b1b8-9f726fe3af09)

Keyword search usually has higher match % than semantic. Does the back and forth between colors and match% bar sizes bother anyone else? See screenshot above. Got feedback on this and punted for later, as this dojo interface is not targeted for external users, but for debugging/tweaking search purposes.