### PR TITLE
Add Alias updates

### DIFF
--- a/ui/client/datasets/FormFields/index.js
+++ b/ui/client/datasets/FormFields/index.js
@@ -41,9 +41,10 @@ export const FormAwareTextField = withStyles((theme) => ({
   inputProps = {},
   InputProps = {},
   required,
+  validate,
   ...props
 }) => {
-  const [field, meta] = useField({ ...props, name });
+  const [field, meta] = useField({ ...props, name, validate });
 
   return (
     <TextField

--- a/ui/client/datasets/annotations/Aliases.js
+++ b/ui/client/datasets/annotations/Aliases.js
@@ -1,21 +1,31 @@
 import React from 'react';
 
 import { FieldArray } from 'formik';
-import { withStyles } from '@material-ui/core/styles';
+import isEmpty from 'lodash/isEmpty';
 
 import AddCircleIcon from '@material-ui/icons/AddCircle';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
 import Button from '@material-ui/core/Button';
 import DeleteIcon from '@material-ui/icons/Delete';
 import IconButton from '@material-ui/core/IconButton';
-import isEmpty from 'lodash/isEmpty';
+import Tooltip from '@material-ui/core/Tooltip';
+
+import { withStyles } from '@material-ui/core/styles';
 
 import { FormAwareTextField } from '../FormFields';
+
+const validateField = (value) => {
+  let errorMessage;
+  if (!value || value === '') {
+    errorMessage = 'Required, or remove alias';
+  }
+  return errorMessage;
+};
 
 /**
  *
  * */
-export const Aliases = withStyles(() => ({
+export const Aliases = withStyles((theme) => ({
   root: {
   },
   aliases: {
@@ -27,8 +37,9 @@ export const Aliases = withStyles(() => ({
     display: 'flex',
   },
   arrow: {
-    display: 'flex',
-    alignItems: 'center'
+    // this exactly vertically centers the arrow
+    // even when the form error height change would cause flex centering to fail
+    marginTop: theme.spacing(2),
   }
 }))(({
   classes, aliases, disabled
@@ -38,49 +49,61 @@ export const Aliases = withStyles(() => ({
     render={(arrayHelpers) => (
 
       <div className={classes.root}>
-        <Button
-          onClick={() => arrayHelpers.push({ id: aliases.length, current: '', new: '' })}
-          color="primary"
-          disabled={disabled}
-          startIcon={<AddCircleIcon />}
+        <Tooltip
+          title="Substitute specific cell values in your column. Set a 'current' value to be
+            replaced and a 'new' value to display. E.g. 'Current: undefined,
+            New: 0' changes 'undefined' cells to '0'."
+          placement="right"
+          arrow
         >
-          Add Alias
-        </Button>
+          <Button
+            onClick={() => arrayHelpers.push({ id: aliases.length, current: '', new: '' })}
+            color="primary"
+            disabled={disabled}
+            startIcon={<AddCircleIcon />}
+          >
+            Add Alias
+          </Button>
+        </Tooltip>
         <ul className={classes.aliases}>
           {aliases && !isEmpty(aliases)
-             && aliases.map((alias, idx) => (
-               <li
-                 className={classes.alias}
-                 key={alias.id}
-               >
-                 <FormAwareTextField
-                   name={`aliases.${idx}.current`}
-                   margin="dense"
-                   label="Current"
-                   disabled={disabled}
-                 />
-
-                 <div className={classes.arrow}>
-                   <ArrowRightIcon />
-                 </div>
-
-                 <FormAwareTextField
-                   name={`aliases.${idx}.new`}
-                   margin="dense"
-                   label="New"
-                   disabled={disabled}
-                 />
-
-                 {!disabled && (
-                   <IconButton
-                     color="secondary"
-                     onClick={() => arrayHelpers.remove(idx)}
-                   >
-                     <DeleteIcon />
-                   </IconButton>
-                 )}
-               </li>
-             ))}
+            && aliases.map((alias, idx) => (
+              <li
+                className={classes.alias}
+                key={alias.id}
+              >
+                <FormAwareTextField
+                  name={`aliases.${idx}.current`}
+                  margin="dense"
+                  label="Current"
+                  required
+                  disabled={disabled}
+                  validate={validateField}
+                />
+                <div className={classes.arrow}>
+                  <ArrowRightIcon />
+                </div>
+                <FormAwareTextField
+                  name={`aliases.${idx}.new`}
+                  margin="dense"
+                  label="New"
+                  required
+                  disabled={disabled}
+                  validate={validateField}
+                />
+                {!disabled && (
+                  <Tooltip title="Remove Alias">
+                    <IconButton
+                      color="secondary"
+                      onClick={() => arrayHelpers.remove(idx)}
+                      style={{ height: '48px' }}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </li>
+            ))}
         </ul>
       </div>
     )}


### PR DESCRIPTION
This adds a tooltip to the `Add Alias` button in the dataset annotation panel that gives a brief overview of what an alias does. It also makes both fields in each alias required on panel save.

<img width="576" alt="Screenshot 2023-07-05 at 3 46 24 PM" src="https://github.com/jataware/dojo/assets/2448578/cd526f45-3316-4fc2-b517-ef56a80b05c1">
