### PR TITLE
Fix Lat/Lon order issue, make primary lat/lon required for geo transformations

### DIFF
--- a/api/validation/MetadataSchema.py
+++ b/api/validation/MetadataSchema.py
@@ -154,18 +154,18 @@ class TimeRange(BaseModel):
 
 class RegridGeo(BaseModel):
     datetime_column: List[str]
-    geo_columns: List[str]
+    geo_columns: Dict[str, str]
     scale: float
     scale_multi: float
 
 class ScaleTime(BaseModel):
     datetime_bucket: str
     datetime_column: str
-    geo_columns: List[str]
+    geo_columns: Dict[str, str]
     aggregation_function_list: List[str]
 
 class ClipGeo(BaseModel):
-    geo_columns: List[str]
+    geo_columns: Dict[str, str]
     map_shapes: List[List[LatLong]]
 
 class ClipTime(BaseModel):

--- a/tasks/tasks/transformation_processors.py
+++ b/tasks/tasks/transformation_processors.py
@@ -131,7 +131,7 @@ def clip_time(context, filename=None, **kwargs):
 
     response = {
         "message": "Time values not clipped, some information was not provided (time column or time range list).",
-        "dataframe": json.loads(json.dumps(original_dataframe)),
+        "dataframe": original_dataframe.to_json(),
     }
     return response
 
@@ -150,13 +150,20 @@ def scale_time(context, filename=None, **kwargs):
     geo_columns = kwargs.get("geo_columns", None)
 
     if time_column and time_bucket and aggregation_list:
-        clipped_df = elwood.rescale_dataframe_time(
-            dataframe=original_dataframe,
-            time_column=time_column,
-            time_bucket=time_bucket,
-            aggregation_functions=aggregation_list,
-            geo_columns=geo_columns,
-        )
+        try:
+            clipped_df = elwood.rescale_dataframe_time(
+                dataframe=original_dataframe,
+                time_column=time_column,
+                time_bucket=time_bucket,
+                aggregation_functions=aggregation_list,
+                geo_columns=geo_columns,
+            )
+        except ValueError as e:
+            response = {
+                "message": f"Time not rescaled due to error: {str(e)}",
+                "dataframe": original_dataframe.to_json(),
+            }
+            return response
 
         json_dataframe_preview = clipped_df.head(100).to_json(default_handler=str)
         rows_post_clip = len(clipped_df.index)
@@ -195,7 +202,7 @@ def scale_time(context, filename=None, **kwargs):
 
     response = {
         "message": "Time not rescaled, some information was not provided (time column, time bucket, or aggregation function list).",
-        "dataframe": json.loads(json.dumps(original_dataframe)),
+        "dataframe": original_dataframe.to_json(),
     }
     return response
 

--- a/tasks/tasks/transformation_processors.py
+++ b/tasks/tasks/transformation_processors.py
@@ -23,9 +23,9 @@ def clip_geo(context, filename=None, **kwargs):
 
     # Main Call
     shape_list = kwargs.get("map_shapes", [])
-    geo_columns = kwargs.get("geo_columns", [])
+    geo_columns = kwargs.get("geo_columns", {})
 
-    if shape_list and geo_columns:
+    if shape_list and geo_columns and 'lat_column' in geo_columns and 'lon_column' in geo_columns:
         clipped_df = elwood.clip_geo(
             dataframe=original_dataframe,
             geo_columns=geo_columns,
@@ -258,7 +258,7 @@ def regrid_geo(context, filename=None, **kwargs):
 
     response = {
         "message": "Geography not rescaled, some information was not provided (geo_columns, scale_multiplier).",
-        "dataframe": json.loads(json.dumps(original_dataframe)),
+        "dataframe": original_dataframe.to_json(),
     }
     return response
 
@@ -269,9 +269,9 @@ def get_boundary_box(context, filename=None, **kwargs):
     original_dataframe = pd.read_csv(file, delimiter=",")
 
     # Main Call
-    geo_columns = kwargs.get("geo_columns", [])
+    geo_columns = kwargs.get("geo_columns", {})
 
-    if geo_columns:
+    if geo_columns and 'lat_column' in geo_columns and 'lon_column' in geo_columns:
         boundary_dict = elwood.get_boundary_box(
             dataframe=original_dataframe,
             geo_columns=geo_columns,

--- a/ui/client/datasets/DataTransformation/DataTransformation.js
+++ b/ui/client/datasets/DataTransformation/DataTransformation.js
@@ -27,6 +27,7 @@ import AdjustGeoResolution from './AdjustGeoResolution';
 import TransformationButton from './TransformationButton';
 import useElwoodData from './useElwoodData';
 import {
+  getPrimaryLatLonColumns,
   generateProcessGeoResArgs,
   generateProcessTempResArgs,
   generateProcessGeoCovArgs,
@@ -156,27 +157,20 @@ const DataTransformation = withStyles(() => ({
   };
 
   const generateFetchGeoResArgs = useCallback((argsAnnotations) => {
-    const args = {};
-    argsAnnotations.annotations.geo.forEach((geo) => {
-      if (geo.geo_type === 'latitude') {
-        args.lat_column = geo.name;
-      } else {
-        args.lon_column = geo.name;
-      }
-    });
-    if (args.lat_column && args.lon_column) {
-      return args;
+    const geoColumns = getPrimaryLatLonColumns(argsAnnotations.annotations.geo);
+    if (geoColumns) {
+      return geoColumns;
     }
-    return 'Geospatial resolution cannot be transformed without annotated lat/lon columns';
+    return 'Geospatial resolution cannot be transformed without annotated lat/lng columns marked as primary geo';
   }, []);
 
   const generateFetchGeoBoundaryArgs = useCallback((argsAnnotations) => {
-    const args = { geo_columns: [] };
-    argsAnnotations.annotations.geo.forEach((geo) => args.geo_columns.push(geo.name));
-    if (args.geo_columns.length < 2) {
-      return 'Geospatial coverage cannot be transformed without annotated lat/lon columns';
+    const geoColumns = getPrimaryLatLonColumns(argsAnnotations.annotations.geo);
+
+    if (geoColumns) {
+      return { geo_columns: geoColumns };
     }
-    return args;
+    return 'Geospatial coverage cannot be transformed without annotated lat/lng columns marked as primary geo';
   }, []);
 
   const generateFetchTemporalArgs = useCallback((argsAnnotations) => {

--- a/ui/client/datasets/DataTransformation/dataTransformationHelpers.js
+++ b/ui/client/datasets/DataTransformation/dataTransformationHelpers.js
@@ -25,7 +25,7 @@ export const generateProcessTempResArgs = (annotations, resolution, aggregation)
     aggregation_function_list: [aggregation],
     // TODO: the order of these shouldn't matter, as these are just columns that we skip
     // for temporal resolution scaling?
-    geo_columns: [geoColumns?.lat_column, geoColumns?.lon_column],
+    geo_columns: geoColumns,
   };
 
   return args;

--- a/ui/client/datasets/DataTransformation/dataTransformationHelpers.js
+++ b/ui/client/datasets/DataTransformation/dataTransformationHelpers.js
@@ -1,32 +1,53 @@
+// this helps generate the lat/lon column arguments for all our geo elwood calls
+export const getPrimaryLatLonColumns = (geoAnnotations) => {
+  let lat_column = null;
+  let lon_column = null;
+  geoAnnotations.forEach((geo) => {
+    // only include the columns if they are primary and lat/lon
+    if (geo.primary_geo === true) {
+      if (geo.geo_type === 'latitude') {
+        lat_column = geo.name;
+      }
+      if (geo.geo_type === 'longitude') {
+        lon_column = geo.name;
+      }
+    }
+  });
+  // Only return anything if we have both, otherwise return null
+  return (lat_column && lon_column) ? { lat_column, lon_column } : null;
+};
+
 export const generateProcessTempResArgs = (annotations, resolution, aggregation) => {
+  const geoColumns = getPrimaryLatLonColumns(annotations.annotations.geo);
   const args = {
     datetime_column: annotations.annotations.date[0].name,
     datetime_bucket: resolution.alias,
     aggregation_function_list: [aggregation],
-    geo_columns: [],
+    // TODO: the order of these shouldn't matter, as these are just columns that we skip
+    // for temporal resolution scaling?
+    geo_columns: [geoColumns?.lat_column, geoColumns?.lon_column],
   };
-  annotations.annotations.geo.forEach((geo) => args.geo_columns.push(geo.name));
 
   return args;
 };
 
 export const generateProcessGeoResArgs = (annotations, newMapResolution, oldMapResolution) => {
+  const geoColumns = getPrimaryLatLonColumns(annotations.annotations.geo);
   const args = {
     datetime_column: [annotations?.annotations.date[0].name],
-    geo_columns: [],
+    geo_columns: geoColumns,
     scale_multi: newMapResolution,
     scale: oldMapResolution,
   };
-  annotations.annotations.geo.forEach((geo) => args.geo_columns.push(geo.name));
   return args;
 };
 
 export const generateProcessGeoCovArgs = (annotations, drawings) => {
+  const geoColumns = getPrimaryLatLonColumns(annotations.annotations.geo);
   const args = {
     map_shapes: drawings,
-    geo_columns: [],
+    geo_columns: geoColumns,
   };
-  annotations.annotations.geo.forEach((geo) => args.geo_columns.push(geo.name));
   return args;
 };
 


### PR DESCRIPTION
This PR primarily switches out the `geo_columns` list arguments for `{ lat_column: ..., lon_column }` dict arguments whenever it's being passed from the frontend. 

As I pulled over some of the changes from https://github.com/jataware/dojo/pull/116 (specifically this commit: https://github.com/jataware/dojo/pull/116/commits/27795818b9963b142f446bac75aaa9be360f154c) to do this PR, I also made primary lat/lon columns required to see the geo transformation panels at all. This helps deal with buggy behavior when we have admin geo fields annotated but not lat/lon, and will help pave the way for https://github.com/jataware/dojo/pull/118 being released before 116. 

There are also a couple small changes to `transformation_processors.py`, mostly switching the default geo_columns to `{}`, but also changing the error handling for the `regrid_geo` job in case incorrect arguments are passed in. This now returns an error that the frontend can handle rather than throwing an exception in the server, at least with some basic manual testing. 

Elwood PR: https://github.com/jataware/elwood/pull/18