### PR TITLE
Version bumps elwood

### DIFF
--- a/tasks/tasks/requirements.txt
+++ b/tasks/tasks/requirements.txt
@@ -5,7 +5,7 @@ h5netcdf==1.0.1
 numpy==1.22
 netCDF4==1.5.3
 matplotlib==3.5.2
-elwood==0.1.2
+elwood==0.1.3
 pandas==1.5.3
 python-dateutil==2.8.2
 raster2xyz==0.1.3


### PR DESCRIPTION
Accidentally merged https://github.com/jataware/dojo/pull/125 before pushing the version bump commit, so here it is in a separate PR. 