### PR TITLE
Fix Dataset Update Metadata, remove ontologies; cleanup

### DIFF
--- a/api/src/indicators.py
+++ b/api/src/indicators.py
@@ -349,8 +349,10 @@ def publish_indicator(indicator_id: str):
         # Update indicator model with ontologies from UAZ
         indicator = es.get(index="indicators", id=indicator_id)["_source"]
         indicator["published"] = True
+        # NOTE get_ontologies has a side effect of PUT to UAZ url
         data = get_ontologies(indicator, type="indicator")
         logger.info(f"Sent indicator to UAZ")
+        logger.info(f"===\n exactly before indexis indicators with ontologies, data: {data}")
         es.index(index="indicators", body=data, id=indicator_id)
 
         # Notify Causemos that an indicator was created

--- a/api/src/indicators.py
+++ b/api/src/indicators.py
@@ -349,11 +349,8 @@ def publish_indicator(indicator_id: str):
         # Update indicator model with ontologies from UAZ
         indicator = es.get(index="indicators", id=indicator_id)["_source"]
         indicator["published"] = True
-        # NOTE get_ontologies has a side effect of PUT to UAZ url
-        data = get_ontologies(indicator, type="indicator")
-        logger.info(f"Sent indicator to UAZ")
-        logger.info(f"===\n exactly before indexis indicators with ontologies, data: {data}")
-        es.index(index="indicators", body=data, id=indicator_id)
+        # data = get_ontologies(indicator, type="indicator")
+        # es.index(index="indicators", body=data, id=indicator_id)
 
         # Notify Causemos that an indicator was created
         plugin_action("before_publish", data=indicator, type="indicator")

--- a/api/src/plugins/__init__.py
+++ b/api/src/plugins/__init__.py
@@ -47,9 +47,9 @@ class PluginHandler:
 
 class PluginInterface:
     """
-        Interface 
+        Interface
     """
-    
+
     def before_create(self, data, type):
         pass
 
@@ -88,7 +88,6 @@ class PluginInterface:
 
     def post_run_model(self, model, run_id):
         pass
-
 
     def on_run_success(self, model, run_id):
         pass

--- a/api/src/plugins/causemos.py
+++ b/api/src/plugins/causemos.py
@@ -11,12 +11,14 @@ from validation import ModelSchema
 
 from src.settings import settings
 from src.models import model_versions
-
+from src.data import get_context
 
 class CausemosPlugin(PluginInterface):
     def publish(self, data, type):
         if settings.DEBUG:
             return
+
+        logger.info(f"\n ===== CausemosPlugin `publish` method running with data: {data}")
 
         if type == "model":
             notify_data = convert_to_causemos_format(data)
@@ -34,9 +36,10 @@ class CausemosPlugin(PluginInterface):
             self.submit_run(notify_data)
 
         if type == "indicator":
+            uuid = data["id"]
+            full_context = get_context(uuid)
             # Notify causemos of the new indicator
-            # logger.info("causemos indicator", json.dumps(data, indent=2))
-            self.notify_causemos(data=data, entity_type="indicator")
+            self.notify_causemos(data=full_context["dataset"], entity_type="indicator")
 
 
     def notify_causemos(self, data, entity_type="indicator"):

--- a/api/src/plugins/causemos.py
+++ b/api/src/plugins/causemos.py
@@ -18,8 +18,6 @@ class CausemosPlugin(PluginInterface):
         if settings.DEBUG:
             return
 
-        logger.info(f"\n ===== CausemosPlugin `publish` method running with data: {data}")
-
         if type == "model":
             notify_data = convert_to_causemos_format(data)
 

--- a/api/src/plugins/sync.py
+++ b/api/src/plugins/sync.py
@@ -11,7 +11,7 @@ from validation import IndicatorSchema
 class SyncPlugin(PluginInterface):
 
     # Sync annotations to indicators
-    def publish(self, data, type="indicator"):
+    def before_publish(self, data, type="indicator"):
         if type == "indicator":
             uuid = data["id"]
             context = get_context(uuid)
@@ -20,6 +20,11 @@ class SyncPlugin(PluginInterface):
             qualifier_outputs = []
             outputs = []
             feature_names = []
+
+            logger.info(f"\n ===== SyncPlugin `publish` method running with id: {uuid}")
+
+            logger.info(f"SyncPlugin run with the following indicator context:\n{context}")
+
             for feature in context["annotations"]["annotations"]["feature"]:
 
                 feature_names.append(

--- a/api/src/plugins/sync.py
+++ b/api/src/plugins/sync.py
@@ -21,10 +21,6 @@ class SyncPlugin(PluginInterface):
             outputs = []
             feature_names = []
 
-            logger.info(f"\n ===== SyncPlugin `publish` method running with id: {uuid}")
-
-            logger.info(f"SyncPlugin run with the following indicator context:\n{context}")
-
             for feature in context["annotations"]["annotations"]["feature"]:
 
                 feature_names.append(


### PR DESCRIPTION
Addresses #129 

<details><summary>Logs from testmos on publishing while REGISTERING a datatset</summary><p>
```
INFO:main:Path: api/maas/indicators/post-process, Method: POST, Headers: Headers({'host': 'testmos:8012', 'user-agent': 'python-requests/2.25.1', 'accept-encoding': 'gzip, deflate', 'accept': '*/*', 'connection': 'keep-alive', 'content-type': 'application/json', 'content-length': '3762', Body: b'{"id": "6e1715c5-0c54-41d5-a3a1-fcf68477bed6", "name": "after remove ontologies and fix publish", "family_name": null, "description": "after remove ontologies and fix publish", "created_at": 1689798463535, "category": null, "domains": ["Mathematics"], "maintainer": {"name": "joel", "email": "joel@jata.com", "organization": "", "website": ""}, "data_paths": ["s3://datasets/6e1715c5-0c54-41d5-a3a1-fcf68477bed6/6e1715c5-0c54-41d5-a3a1-fcf68477bed6.parquet.gzip"], "outputs": [{"unit": "dw", "is_primary": true, "name": "value", "description": "dwd", "alias": {}, "unit_description": "", "display_name": "value", "type": "float", "data_resolution": {"temporal_resolution": "annual", "spatial_resolution": []}, "ontologies": {}}], "qualifier_outputs": [{"unit": null, "related_features": ["value"], "name": "date", "description": "dwd", "unit_description": null, "qualifier_role": "breakdown", "display_name": "date", "type": "datetime", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "country", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "country", "type": "country", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "admin1", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "admin1", "type": "admin1", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "admin2", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "admin2", "type": "admin2", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "admin3", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "admin3", "type": "admin3", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "lat", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "lat", "type": "lat", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "lng", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "lng", "type": "lng", "ontologies": {}}], "tags": [], "geography": {"country": ["Mexico", "Afghanistan", "Finland", "Gabon", "Australia", "Canada", "Russia", "Greece", "Botswana", "Mali", "China", "United States", "Egypt", "Sudan", "C\\u00f4te d\'Ivoire", "Brazil"], "admin1": ["Chihuahua", "Kandahar", "Oulu", "Wouleu-Ntem", "Western Australia", "Nunavut", "Tuva", "Epirus and Western Macedonia", "Kweneng", "Queensland", "Nenets", "Timbuktu", "Guangdong", "Sakha", "Texas", "Dagestan", "Al Wadi al Jadid", "North Darfur", "Khabarovsk", "Nei Mongol", "Como\\u00e9", "Tocantins"], "admin2": ["Camargo", "Kandahar City", "Northern Ostrobothnia", "Haut-Ntem", "East Pilbara", "Keewatin", "Kyzylskiy rayon", "Epirus", "Kweneng South", "Central Highlands", "Nenetskiy AOk", "Goundam", "Qingyuan", "Eveno-Bytantayskiy rayon", "Schleicher", "Nogayskiy rayon", "Al-Wahat al-Kharijah", "Um Kadada", "Tuguro-Chumikanskiy rayon", "Hulunbuir", "Sud Como\\u00e9", "Natividade"], "admin3": []}, "period": {"gte": 1627948800000, "lte": 6739200000}, "deprecated": false, "data_sensitivity": "", "data_quality": "", "published": true, "fileData": {"raw": {"uploaded": true, "url": "output_0.9_1.2.csv", "rawFileName": "raw_data.csv"}}, "data_paths_normalized": ["s3://datasets/normalized/6e1715c5-0c54-41d5-a3a1-fcf68477bed6/6e1715c5-0c54-41d5-a3a1-fcf68477bed6_normalized.parquet.gzip"], "data_paths_normalized_robust": ["s3://datasets/normalized/6e1715c5-0c54-41d5-a3a1-fcf68477bed6/6e1715c5-0c54-41d5-a3a1-fcf68477bed6_normalized_robust.parquet.gzip"], "temporal_resolution": "annual", "feature_names": ["value"]}'
```</p>
</details>



<details><summary>Logs from testmos on publishing while UPDATING a datatset</summary><p>
```
INFO:main:Path: api/maas/indicators/post-process, Method: POST, Headers: Headers({'host': 'testmos:8012', 'user-agent': 'python-requests/2.25.1', 'accept-encoding': 'gzip, deflate', 'accept': '*/*', 'connection': 'keep-alive', 'content-type': 'application/json', 'content-length': '3714'}), Body: b'{"id": "6e1715c5-0c54-41d5-a3a1-fcf68477bed6", "name": "UPDATED", "family_name": null, "description": "UPDATED", "created_at": 1689799712429, "category": null, "domains": ["Mathematics"], "maintainer": {"name": "UPDATED", "email": "joel@jata.com", "organization": "", "website": ""}, "data_paths": ["s3://datasets/6e1715c5-0c54-41d5-a3a1-fcf68477bed6/6e1715c5-0c54-41d5-a3a1-fcf68477bed6.parquet.gzip"], "outputs": [{"unit": "UPDATED", "is_primary": true, "name": "value", "description": "UPDATED", "alias": {}, "unit_description": "", "display_name": "value", "type": "float", "data_resolution": {"temporal_resolution": "annual", "spatial_resolution": []}, "ontologies": {}}], "qualifier_outputs": [{"unit": null, "related_features": ["value"], "name": "date", "description": "UPDATED", "unit_description": null, "qualifier_role": "breakdown", "display_name": "date", "type": "datetime", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "country", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "country", "type": "country", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "admin1", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "admin1", "type": "admin1", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "admin2", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "admin2", "type": "admin2", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "admin3", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "admin3", "type": "admin3", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "lat", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "lat", "type": "lat", "ontologies": {}}, {"unit": null, "related_features": ["value"], "name": "lng", "description": "location", "unit_description": null, "qualifier_role": "breakdown", "display_name": "lng", "type": "lng", "ontologies": {}}], "tags": [], "geography": {"country": ["Mexico", "Afghanistan", "Finland", "Gabon", "Australia", "Canada", "Russia", "Greece", "Botswana", "Mali", "China", "United States", "Egypt", "Sudan", "C\\u00f4te d\'Ivoire", "Brazil"], "admin1": ["Chihuahua", "Kandahar", "Oulu", "Wouleu-Ntem", "Western Australia", "Nunavut", "Tuva", "Epirus and Western Macedonia", "Kweneng", "Queensland", "Nenets", "Timbuktu", "Guangdong", "Sakha", "Texas", "Dagestan", "Al Wadi al Jadid", "North Darfur", "Khabarovsk", "Nei Mongol", "Como\\u00e9", "Tocantins"], "admin2": ["Camargo", "Kandahar City", "Northern Ostrobothnia", "Haut-Ntem", "East Pilbara", "Keewatin", "Kyzylskiy rayon", "Epirus", "Kweneng South", "Central Highlands", "Nenetskiy AOk", "Goundam", "Qingyuan", "Eveno-Bytantayskiy rayon", "Schleicher", "Nogayskiy rayon", "Al-Wahat al-Kharijah", "Um Kadada", "Tuguro-Chumikanskiy rayon", "Hulunbuir", "Sud Como\\u00e9", "Natividade"], "admin3": []}, "period": {"gte": 1627948800000, "lte": 6739200000}, "deprecated": false, "data_sensitivity": "", "data_quality": "", "published": true, "fileData": {"raw": {"uploaded": true, "url": "output_0.9_1.2.csv", "rawFileName": "raw_data.csv"}}, "data_paths_normalized": ["s3://datasets/normalized/6e1715c5-0c54-41d5-a3a1-fcf68477bed6/6e1715c5-0c54-41d5-a3a1-fcf68477bed6_normalized.parquet.gzip"], "data_paths_normalized_robust": ["s3://datasets/normalized/6e1715c5-0c54-41d5-a3a1-fcf68477bed6/6e1715c5-0c54-41d5-a3a1-fcf68477bed6_normalized_robust.parquet.gzip"], "temporal_resolution": "annual", "feature_names": ["value"]}'
```</p>
</details>
