### PR TITLE
Adds required status to TransformationButton on Data Transformation Page

### DIFF
--- a/ui/client/datasets/DataTransformation/TransformationButton.js
+++ b/ui/client/datasets/DataTransformation/TransformationButton.js
@@ -23,6 +23,9 @@ const TransformationButton = withStyles(({ palette }) => ({
   close: {
     color: palette.info.light,
   },
+  required: {
+    color: palette.warning.light,
+  },
   disabled: {
     color: palette.text.disabled,
   },
@@ -37,6 +40,7 @@ const TransformationButton = withStyles(({ palette }) => ({
   title,
   onClick,
   loading,
+  required,
   error,
 }) => {
   const displayIcon = () => {
@@ -48,19 +52,33 @@ const TransformationButton = withStyles(({ palette }) => ({
       return <CircularProgress thickness={4.5} size={25} />;
     }
 
+    if (required && !isComplete && !error) {
+      return <InfoIcon className={classes.required} fontSize="large" />;
+    }
+
     if (error !== false) {
       return <InfoIcon className={classes.close} fontSize="large" />;
     }
   };
 
-  // If no message is supplied from the backend, we default to true, so use a default message
-  const tooltipText = error.length ? error : 'This data is not available for transformation';
+  const displayTooltipText = () => {
+    // don't show a tooltip if the job is still loading
+    if (loading) return '';
+    if (error && error.length) return error;
+    // if it doesn't come with an error message, use this default
+    if (error) return 'This data is not available for transformation';
+    if (required && !isComplete && !error) {
+      // if it's required and not complete
+      return 'Please review this transformation before continuing';
+    }
+    return '';
+  };
 
   return (
     <Tooltip
       arrow
       placement="right"
-      title={error ? tooltipText : ''}
+      title={displayTooltipText()}
     >
       <span style={{ position: 'relative' }}>
         <ListItem


### PR DESCRIPTION
Currently only used by GADM Resolution link. 

<img width="597" alt="Screenshot 2023-07-26 at 1 28 52 PM" src="https://github.com/jataware/dojo/assets/2448578/24524b64-a49e-452c-b6c4-24ec4ca34b7d">
