### PR TITLE
Handled case where no primary geo is set while running rqworker- gadm…

### DIFF
--- a/tasks/tasks/gadm_processors.py
+++ b/tasks/tasks/gadm_processors.py
@@ -17,82 +17,26 @@ def resolution_alternatives(context, filename=None, **kwargs):
 
     admin_level = kwargs.get("admin_level", "country")
 
+    has_primary_geo = False
+
     geo_column = ""
     for geo in context.get("annotations").get("annotations").get("geo"):
         if geo.get("primary_geo", False):
+            has_primary_geo = True
             geo_type = admin_level_to_geo_type(admin_level=admin_level)
             if geo.get("geo_type") == geo_type:
                 geo_column = geo.get("name")
                 break
             geo_column = geo.get("name")
 
+    if not has_primary_geo:
+        return {
+            "field": None,
+            "fuzzy_match": []
+        }
+
     # Run job
     gadm_response = elwood.get_gadm_matches(original_dataframe, geo_column, admin_level)
-
-    # Return hardcoded response in job
-    # provide gadm alternatives
-    mock_gadm_alternatives = {
-        "field": "CountryMockityMocked",
-        "fuzzy_match": [
-            {
-                "raw_value": "Korea",
-                "gadm_resolved": "Republic of Korea",
-                "confidence": 85,
-                "alternatives": [
-                    "Republic of Korea",
-                    "Democratic People's Republic of Korea"
-                ]
-            },
-            {
-                "raw_value": "dominica",
-                "gadm_resolved": "Dominica",
-                "confidence": 85,
-                "alternatives": [
-                    "Dominica",
-                    "Dominican Republic"
-                ]
-            },
-            {
-                "raw_value": "congo",
-                "gadm_resolved": "Democratic Republic of the Congo",
-                "confidence": 85,
-                "alternatives": [
-                    "Democratic Republic of the Congo",
-                    "Republic of the Congo"
-                ]
-            },
-            {
-                "raw_value": "gunea",
-                "gadm_resolved": "Guinea",
-                "confidence": 85,
-                "alternatives": [
-                    "Guinea",
-                    "Guinea-Bissau",
-                    "Equatorial Guinea",
-                    "Guyana",
-                    "Ghana"
-                ]
-            },
-            {
-                "raw_value": "Virgin Islands",
-                "gadm_resolved": "US Virgin Islands",
-                "confidence": 85,
-                "alternatives": [
-                    "US Virgin Islands",
-                    "British Virgin Islands"
-                ]
-            },
-            {
-                "raw_value": "Samoa",
-                "gadm_resolved": "Samoa",
-                "confidence": 85,
-                "alternatives": [
-                    "Samoa",
-                    "American Samoa"
-                ]
-            }
-        ]
-    }
 
     return gadm_response
 


### PR DESCRIPTION
… resolution_alternatives job.

This complements a UI fix where the job won't even get started in the first place, but should help make the system more stable.