### PR TITLE
Dataset geo/date multipart annotation form fix

### DIFF
--- a/ui/client/components/formikComponents/FormikSelect.js
+++ b/ui/client/components/formikComponents/FormikSelect.js
@@ -3,8 +3,20 @@ import { useField, useFormikContext } from 'formik';
 
 import InputLabel from '@mui/material/InputLabel';
 import FormControl from '@mui/material/FormControl';
+import FormHelperText from '@mui/material/FormHelperText';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
+
+// removes the [' '] from dataset multicolumn date & geo, which are there
+// because of the formik getIn selector & its difficulties with .nested names
+// but we need to match the name with the errors object name, which doesn't have the ['']
+function stripBrackets(str) {
+  if (str.startsWith("['") && str.endsWith("']")) {
+    return str.substring(2, str.length - 2);
+  }
+  // if it doesn't have the brackets, return the original string
+  return str;
+}
 
 /**
  * Wraps MUI Select for easier use with Formik. Needs to be within a Formik form.
@@ -16,32 +28,37 @@ const FormikSelect = ({
   squareCorners = false,
   ...props
 }) => {
-  const { setFieldValue } = useFormikContext();
+  const { setFieldValue, errors, touched } = useFormikContext();
   const [field] = useField(name);
 
   const configSelect = {
     ...field,
     ...props,
-    value: field.value || null,
+    value: field.value,
     onChange: (event) => setFieldValue(name, event.target.value),
   };
 
+  const isError = touched[stripBrackets(name)] && errors[stripBrackets(name)];
+
   return (
-    <FormControl {...props}>
-      <InputLabel>{props.label}</InputLabel>
+    <FormControl {...props} error={!!isError}>
+      <InputLabel shrink>{props.label}</InputLabel>
       <Select
+        notched
         {...configSelect}
         // if not squareCorners, default to theme.shape.borderRadius (4px)
         sx={{ borderRadius: squareCorners ? 0 : 1 }}
         inputProps={{
           'aria-label': props.label,
         }}
+        displayEmpty
       >
         {options?.map((option, index) => (
           // eslint-disable-next-line react/no-array-index-key
           <MenuItem key={index} value={option.value}>{option.label}</MenuItem>
         ))}
       </Select>
+      {isError && <FormHelperText>{errors[stripBrackets(name)]}</FormHelperText>}
     </FormControl>
   );
 };

--- a/ui/client/datasets/annotations/MultiColumnGeoSelector.js
+++ b/ui/client/datasets/annotations/MultiColumnGeoSelector.js
@@ -31,7 +31,7 @@ const MultiColumnGeoSelector = ({
   }, [editingColumn.geo_type, editingColumn.name, disabled, setFieldValue]);
 
   return (
-    <FormControl variant="standard">
+    <FormControl variant="standard" fullWidth>
       <FormGroup>
         <Grid
           container

--- a/ui/client/datasets/annotations/annotationRules.js
+++ b/ui/client/datasets/annotations/annotationRules.js
@@ -184,6 +184,19 @@ export function verifyConditionalRequiredFields(annotation) {
     });
   }
 
+  if (annotation['geo.multi-column']) {
+    [
+      'geo.multi-column.admin0',
+      'geo.multi-column.admin1',
+      'geo.multi-column.admin2',
+      'geo.multi-column.admin3',
+    ].forEach((valName) => {
+      if (!annotation[valName]) {
+        errors[valName] = 'Required';
+      }
+    });
+  }
+
   if (annotation.category === CATEGORIES.time) {
     if (!annotation.time_format && !annotation['date.multi-column'] && annotation.date_type !== 'epoch') {
       errors.time_format = 'Required';


### PR DESCRIPTION
https://github.com/jataware/dojo/issues/172

Both the geo & date multipart forms were looking bad (as was the model templater) because the labels weren't shrinking (becoming small at the top of the input). The label ended up overlaid on top of the initially selected input content, making it difficult to read. 

All the uses of FormikSelect - the Templater and both multipart forms - were not showing any `required` errors. This PR also fixes that. 

![Screenshot 2023-10-06 at 11 55 21 AM](https://github.com/jataware/dojo/assets/2448578/e2241702-f553-418d-b3a7-ba9a95d866f4)

