### PR TITLE
Data Transformation: Make Geo & Temporal Resolution Not Required

### DIFF
--- a/ui/client/datasets/DataTransformation/DataTransformation.js
+++ b/ui/client/datasets/DataTransformation/DataTransformation.js
@@ -548,16 +548,6 @@ const DataTransformation = ({
       return true;
     }
 
-    if (!mapResolutionError && !savedMapResolution) {
-      // disable if we are requiring a map resolution to be chosen and it hasn't been
-      return true;
-    }
-
-    if (!timeResolutionError && !savedTimeResolution) {
-      // disable if we are requiring a time resolution to be set and it hasn't been
-      return true;
-    }
-
     if (!gadmResolutionError && !savedGADMOverrides) {
       return true;
     }
@@ -794,7 +784,6 @@ const DataTransformation = ({
           onClick={() => handleDrawerOpen('regridMap')}
           loading={mapResolutionLoading}
           error={mapResolutionError}
-          required={!mapResolutionError}
         />
         <TransformationButton
           isComplete={!!savedDrawings.length}
@@ -811,7 +800,6 @@ const DataTransformation = ({
           onClick={() => handleDrawerOpen('scaleTime')}
           loading={timeResolutionLoading}
           error={timeResolutionError}
-          required={!timeResolutionError}
         />
         <TransformationButton
           isComplete={!!savedTimeBounds}

--- a/ui/client/datasets/DataTransformation/DataTransformation.js
+++ b/ui/client/datasets/DataTransformation/DataTransformation.js
@@ -212,8 +212,6 @@ const DataTransformation = ({
 
   // Handles the next step process after the transformations are complete in <RunTransformation>
   useEffect(() => {
-    // There is always at least one required transformation
-    // time scaling happens even if the user hasn't annotated a date column
     if (allTransformationsComplete) {
       if (jobsConfig.length) {
         // This lets us know that we need to show the spinner when the restore_raw_file job
@@ -654,7 +652,10 @@ const DataTransformation = ({
   };
 
   const processGadmOverrides = () => {
-    transformationsRef.current.overrides = { gadm: savedGADMOverrides };
+    // only add GADM overrides to the transformationsRef if they are present
+    if (!isEmpty(savedGADMOverrides)) {
+      transformationsRef.current.overrides = { gadm: savedGADMOverrides };
+    }
   };
 
   const handleNextStep = () => {
@@ -682,6 +683,11 @@ const DataTransformation = ({
     setJobsConfig(transformations);
     // The actual jump to next step happens in the useEffect at the top of this function
     // after the jobs have completed in RunTransformation
+
+    // if there are no transformations, toggle this to trigger our 'handleNext' useEffect at top
+    if (!transformations.length) {
+      setAllTransformationsComplete(true);
+    }
   };
 
   const drawerInner = () => {
@@ -835,7 +841,7 @@ const DataTransformation = ({
         handleClose={closePrompt}
       />
 
-      {jobsConfig && !transformationProcessingError && (
+      {Boolean(jobsConfig?.length) && !transformationProcessingError && (
         <RunTransformations
           jobsConfig={jobsConfig}
           setAllTransformationsComplete={setAllTransformationsComplete}

--- a/ui/client/datasets/DataTransformation/RunTransformations.js
+++ b/ui/client/datasets/DataTransformation/RunTransformations.js
@@ -11,21 +11,21 @@ import useOrderedElwoodJobs from './useOrderedElwoodJobs';
 const useStyles = makeStyles()((theme) => ({
   backdrop: {
     zIndex: theme.zIndex.drawer + 1000,
-    color: theme.palette.grey[700],
     display: 'flex',
     alignItems: 'flex-end',
     padding: theme.spacing(20),
   },
   progress: {
-    color: theme.palette.grey[300],
-    marginRight: theme.spacing(4),
+    color: theme.palette.grey[100],
   },
   text: {
-    color: theme.palette.grey[300],
+    color: theme.palette.grey[100],
   },
   innerWrapper: {
     display: 'flex',
+    flexDirection: 'column',
     alignItems: 'center',
+    gap: theme.spacing(3),
   },
 }));
 
@@ -40,7 +40,7 @@ const RunTransformations = ({
   setAllTransformationsComplete,
   setTransformationProcessingError,
 }) => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { error, allJobsCompleted } = useOrderedElwoodJobs(jobsConfig);
 
   useEffect(() => {


### PR DESCRIPTION
It turned out this was slightly more complicated than just removing the `required` props and the disabled checks, as the DataTransformation component was relying on the RunTransformation component always running. However, this didn't take much tweaking to fix. 

I also fixed the transformation processing overlay styling.