### PR TITLE
Removes minimap from data modeler

### DIFF
--- a/ui/client/dagpipes/PipeEditor.js
+++ b/ui/client/dagpipes/PipeEditor.js
@@ -14,6 +14,7 @@ import ReactFlow, {
 } from 'reactflow';
 
 import Button from '@mui/material/Button';
+import Tooltip from '@mui/material/Tooltip';
 
 import { makeStyles } from 'tss-react/mui';
 
@@ -336,6 +337,23 @@ const PipeEditor = () => {
     }).catch((error) => console.log('There was an error creating the data modeling:', error));
   };
 
+  const processDisabled = !geoResolutionColumn || !timeResolutionColumn || !nodes.length;
+  let disabledProcessTooltip = 'Please select ';
+
+  if (!geoResolutionColumn && !timeResolutionColumn) {
+    // both geo and time are missing
+    disabledProcessTooltip += 'both geo and time resolutions in Load Nodes or sidebar';
+  } else if (!geoResolutionColumn) {
+    // only geo is missing
+    disabledProcessTooltip += 'geo resolution in Load Nodes or sidebar';
+  } else if (!timeResolutionColumn) {
+    // only time is missing
+    disabledProcessTooltip += 'time resolution in Load Nodes or sidebar';
+  } else if (!nodes.length) {
+    // if both resolutions are chosen but no nodes
+    disabledProcessTooltip = 'Please ensure nodes are added to the graph';
+  }
+
   return (
     <div className={classes.innerWrapper}>
       <div
@@ -387,16 +405,20 @@ const PipeEditor = () => {
         <DragBar />
         <div className={classes.lowerSidebar}>
           <ModelerResolution />
-          <Button
-            variant="contained"
-            color="primary"
-            fullWidth
-            disabled={!geoResolutionColumn || !timeResolutionColumn || !nodes.length}
-            onClick={onProcessClick}
-            sx={{ marginTop: 2 }}
-          >
-            Process
-          </Button>
+          <Tooltip title={processDisabled ? disabledProcessTooltip : ''}>
+            <span>
+              <Button
+                variant="contained"
+                color="primary"
+                fullWidth
+                disabled={processDisabled}
+                onClick={onProcessClick}
+                sx={{ marginTop: 2 }}
+              >
+                Process
+              </Button>
+            </span>
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/ui/client/dagpipes/PipeEditor.js
+++ b/ui/client/dagpipes/PipeEditor.js
@@ -7,7 +7,6 @@ import axios from 'axios';
 import ReactFlow, {
   addEdge,
   ReactFlowProvider,
-  MiniMap,
   Controls,
   Background,
   useNodesState,
@@ -154,7 +153,6 @@ const PipeEditor = () => {
   }, [nodes, setSelectedNode]);
 
   const [reactFlowInstance, setReactFlowInstance] = useState(null);
-  const [miniMapHeight, setMiniMapHeight] = useState(120);
 
   const onInit = (rfInstance) => {
     console.log('Flow loaded:', rfInstance);
@@ -338,14 +336,6 @@ const PipeEditor = () => {
     }).catch((error) => console.log('There was an error creating the data modeling:', error));
   };
 
-  const onMiniMapClick = () => {
-    if (miniMapHeight === 120) {
-      setMiniMapHeight(20);
-    } else {
-      setMiniMapHeight(120);
-    }
-  };
-
   return (
     <div className={classes.innerWrapper}>
       <div
@@ -367,12 +357,6 @@ const PipeEditor = () => {
           onDrop={onDrop}
           onDragOver={onDragOver}
         >
-          <MiniMap
-            style={{ height: miniMapHeight }}
-            zoomable
-            pannable
-            onClick={onMiniMapClick}
-          />
           <Controls />
           <Background
             color="#aaa"


### PR DESCRIPTION
Also adds a tooltip to the disabled PROCESS button explaining why it's been disabled, as this was otherwise a mystery to users. 

<img width="839" alt="Screenshot 2023-11-12 at 1 48 42 PM" src="https://github.com/jataware/dojo/assets/2448578/d821f8d8-52d1-4c5d-bd54-f277b81e4c71">
<img width="807" alt="Screenshot 2023-11-12 at 1 50 14 PM" src="https://github.com/jataware/dojo/assets/2448578/576baff8-249e-4857-9fed-fd569a525363">
