### PR TITLE
Update Docs Links

### DIFF
--- a/ui/client/components/UploadFileDialog.js
+++ b/ui/client/components/UploadFileDialog.js
@@ -57,7 +57,7 @@ const UploadFileDialog = ({
         .catch((error) => {
           resolve(error);
           // eslint-disable-next-line no-alert
-          alert(`${error} - Please try to upload again. If this continues see dojo documentation on uploading large files using Dojo's Amazon S3 Bucket. https://www.dojo-modeling.com/large-files.html`);
+          alert(`${error} - Please try to upload again. If this continues see dojo documentation on uploading large files using Dojo's Amazon S3 Bucket. https://www.dojo-modeling.com/details/large-files.html`);
         });
     } catch (error) {
       console.log(error);
@@ -140,7 +140,7 @@ const UploadFileDialog = ({
                           File size over limit - (25mb).
                         </span>
                         <Button
-                          href=" https://www.dojo-modeling.com/large-files.html"
+                          href=" https://www.dojo-modeling.com/details/large-files.html"
                           target="_blank"
                           rel="noopener"
                           className={classes.buttons}

--- a/ui/client/dagpipes/LoadNode.js
+++ b/ui/client/dagpipes/LoadNode.js
@@ -27,7 +27,7 @@ const aggList = aggregation_functions.map((res) => ({ value: res, label: res }))
 const AggregationLabel = ({ text }) => (
   <div>
     {text}
-    <InlineDocIconLink link="aggregation-methods.html" title="aggregation function" />
+    <InlineDocIconLink link="/details/aggregation-methods.html" title="aggregation function" />
   </div>
 );
 

--- a/ui/client/provision.js
+++ b/ui/client/provision.js
@@ -280,7 +280,7 @@ const Provision = () => {
                 <Typography variant="body2">
                   Once the model has been run, you&apos;ll use the&nbsp;
                   <Link
-                    href="https://www.dojo-modeling.com/cheatsheet.html#dojo-terminal-commands"
+                    href="https://www.dojo-modeling.com/details/cheatsheet.html#dojo-terminal-commands"
                     target="_blank"
                     rel="noopener"
                     underline="hover"
@@ -300,7 +300,7 @@ const Provision = () => {
               <Typography variant="body2" gutterBottom>
                 See&nbsp;
                 <Link
-                  href="https://www.dojo-modeling.com/docker.html"
+                  href="https://www.dojo-modeling.com/details/docker.html"
                   target="_blank"
                   rel="noopener"
                   underline="hover"


### PR DESCRIPTION
https://github.com/dojo-modeling/dojo-docs/pull/26 changes the file structure of the Dojo Documentation, so we need to update all of our direct links to the child pages in the docs. They are all now nested under `/details/...`. This changes all the links in Dojo.