### PR TITLE
Fixes Document Explorer full text bug

### DIFF
--- a/api/src/documents.py
+++ b/api/src/documents.py
@@ -472,7 +472,7 @@ def get_document_text(document_id: str,
         try:
             q = {
                 "query": {
-                    "match": {"document_id": document_id}
+                    "match": {"document_id.keyword": document_id}
                 },
                 "sort": [
                     {


### PR DESCRIPTION
Because we were doing a text match instead of a keyword match on the document ids when fetching paragraphs, we were sometimes getting a mixed up set of documents returned. This resulted in a jumble of full text from multiple documents that was unreadable. 

Fixes https://github.com/jataware/dojo/issues/214