### PR TITLE
Fix Docs baseUrl

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -16,7 +16,7 @@ const config = {
   url: 'https://www.dojo-modeling.com/',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/dojo/',
+  baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
Changes baseUrl to '/' as we're no longer under '/dojo'