### PR TITLE
Docs: mobile sidenav fix

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -50,9 +50,12 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }*/
 
+/* these are not guaranteed to be stable class names */
 .navbar {
   background-color:#06B8EF;
   background-image:linear-gradient(to right, rgba(6, 184, 239, 1), rgba(161, 27, 218, 1));
+}
+.navbar__items {
   a, button {
     color: white;
     &:hover {


### PR DESCRIPTION
Fixes issue with white on white sidenav buttons in mobile light mode

Before:
![Screenshot 2024-01-10 at 4 39 30 PM](https://github.com/jataware/dojo/assets/2448578/84448433-e7fa-46e8-b34e-a1f5c85ad1c3)

After:
![Screenshot 2024-01-10 at 4 40 00 PM](https://github.com/jataware/dojo/assets/2448578/693bcb42-d0f3-4018-be59-a039156da772)
