### PR TITLE
Adds open document presentation (`odp`) file support in Document Explorer/Uploads

### DIFF
--- a/ui/client/documents/upload/DropArea.js
+++ b/ui/client/documents/upload/DropArea.js
@@ -60,6 +60,9 @@ const extensionMap = {
   'odt': {
     'application/vnd.oasis.opendocument.text': ['.odt']
   },
+  'odp': {
+    'application/vnd.oasis.opendocument.presentation': ['.odp']
+  },
   'ppt': {
     'application/vnd.ms-powerpoint': ['.ppt']
   },

--- a/ui/client/documents/upload/index.js
+++ b/ui/client/documents/upload/index.js
@@ -303,7 +303,7 @@ const UploadDocumentForm = () => {
         </Alert>
 
         <FileDropSelector
-          acceptExtensions={['pdf', 'doc', 'docx', 'odt', 'ppt', 'pptx']}
+          acceptExtensions={['pdf', 'doc', 'docx', 'odt', 'ppt', 'pptx', 'odp']}
           onFileSelect={handleFileSelect}
           disableSelector={files.length >= 10}
           maxFiles={10}


### PR DESCRIPTION
Had previously added ppt, pptx, doc, docx, odt. Was missing the open document presentation format. Any document file (text, presentation) that isn't a PDF will be converted, and stored, to PDF by the system.

I'll merge this PR immediately, since it doesn't affect anything and the file format is not as common as pptx.