### PR TITLE
Remove Register a New Model/Dataset buttons from View Models/Datasets

### DIFF
--- a/ui/client/components/Sidebar.js
+++ b/ui/client/components/Sidebar.js
@@ -121,7 +121,7 @@ const Sidebar = ({ open, handleDrawerClose }) => {
         ))}
       </List>
     </Drawer>
-  )
+  );
 };
 
 export default Sidebar;

--- a/ui/client/components/ViewDatasets.js
+++ b/ui/client/components/ViewDatasets.js
@@ -270,16 +270,6 @@ function ViewDatasets() {
                   datasets={displayedDatasets}
                 />
                 <Button
-                  component={Link}
-                  size="large"
-                  variant="outlined"
-                  color="primary"
-                  disableElevation
-                  to="/datasets/register"
-                >
-                  Register a New Dataset
-                </Button>
-                <Button
                   color="primary"
                   disableElevation
                   variant="outlined"

--- a/ui/client/components/ViewDatasets.js
+++ b/ui/client/components/ViewDatasets.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import axios from 'axios';
 
 import Button from '@mui/material/Button';

--- a/ui/client/components/ViewModels.js
+++ b/ui/client/components/ViewModels.js
@@ -323,16 +323,6 @@ const ViewModels = ({
             items={displayedModels}
           />
           <Button
-            component={Link}
-            size="large"
-            variant="outlined"
-            color="primary"
-            disableElevation
-            to="/model"
-          >
-            Register a New Model
-          </Button>
-          <Button
             color="primary"
             disableElevation
             variant="outlined"

--- a/ui/client/components/ViewModels.js
+++ b/ui/client/components/ViewModels.js
@@ -15,7 +15,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 
 import { makeStyles } from 'tss-react/mui';
 
-import { useHistory, Link } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import ExpandableDataGridCell from './ExpandableDataGridCell';
 import LoadingOverlay from './LoadingOverlay';

--- a/ui/client/documents/upload/DropArea.js
+++ b/ui/client/documents/upload/DropArea.js
@@ -51,22 +51,22 @@ const extensionMap = {
   xlsx: {
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx']
   },
-  'docx': {
+  docx: {
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx']
   },
-  'doc': {
+  doc: {
     'application/msword': ['.doc']
   },
-  'odt': {
+  odt: {
     'application/vnd.oasis.opendocument.text': ['.odt']
   },
-  'odp': {
+  odp: {
     'application/vnd.oasis.opendocument.presentation': ['.odp']
   },
-  'ppt': {
+  ppt: {
     'application/vnd.ms-powerpoint': ['.ppt']
   },
-  'pptx': {
+  pptx: {
     'application/vnd.openxmlformats-officedocument.presentationml.presentation': ['.pptx']
   }
 };

--- a/ui/client/documents/upload/PDFViewer.js
+++ b/ui/client/documents/upload/PDFViewer.js
@@ -5,33 +5,30 @@ import Typography from '@mui/material/Typography';
 /**
  *
  **/
-export default ({ file }) => {
-
-  return (
-    <Paper
-      elevation={0}
-      sx={{ padding: '1rem', height: '100%' }}
+export default ({ file }) => (
+  <Paper
+    elevation={0}
+    sx={{ padding: '1rem', height: '100%' }}
+  >
+    <Typography
+      variant="h6"
+      gutterBottom
     >
-      <Typography
-        variant="h6"
-        gutterBottom
-      >
-        {file.name}
+      {file.name}
+    </Typography>
+
+    {file.type === 'application/pdf' ? (
+      <embed
+        src={file.blobUrl}
+        type="application/pdf"
+        height="95%"
+        width="100%"
+      />
+    ) : (
+      <Typography variant="body2" color="textSecondary">
+        Cannot preview non-PDF files.
       </Typography>
+    )}
 
-      {file.type === 'application/pdf' ? (
-        <embed
-          src={file.blobUrl}
-          type="application/pdf"
-          height="95%"
-          width="100%"
-        />
-      ) : (
-        <Typography variant="body2" color="textSecondary">
-          Cannot preview non-PDF files.
-        </Typography>
-      )}
-
-    </Paper>
-  );
-}
+  </Paper>
+);

--- a/ui/client/documents/upload/index.js
+++ b/ui/client/documents/upload/index.js
@@ -190,11 +190,10 @@ const UploadDocumentForm = () => {
           })
           .then((pdf) => getFormattedPDFMetadata(pdf));
       })
-      .catch((readPDFerror) => {
+      .catch(() => {
         setAcceptedFilesParsed((current) => current + 1);
         return defaultValues;
-      })
-    );
+      }));
 
     Promise.all(pdfData)
       .then((allPdfData) => {


### PR DESCRIPTION
Removes 'Register a new model/dataset' buttons from View Models/Datasets. These are now redundant with the sidebar