### PR TITLE
Data Modeling Selector Improvements

### DIFF
--- a/ui/client/components/ExpandableDataGridCell.js
+++ b/ui/client/components/ExpandableDataGridCell.js
@@ -17,15 +17,34 @@ const ExpandableDataGridCell = React.memo((props) => {
   const wrapper = React.useRef(null);
   const cellDiv = React.useRef(null);
   const cellValue = React.useRef(null);
+  const textMeasureRef = React.useRef(null);
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [showFullCell, setShowFullCell] = React.useState(false);
   const [showPopper, setShowPopper] = React.useState(false);
+  const [popperWidth, setPopperWidth] = React.useState(width);
 
   const handleMouseEnter = () => {
     const isCurrentlyOverflown = isOverflown(cellValue.current);
     setShowPopper(isCurrentlyOverflown);
     setAnchorEl(cellDiv.current);
     setShowFullCell(true);
+
+    // Split value into words and find the longest one
+    const words = value.split(' ');
+    const longestWord = words.reduce((word1, word2) => (
+      word1.length > word2.length ? word1 : word2
+    ), '');
+
+    // Measure the width of the longest word
+    textMeasureRef.current.textContent = longestWord;
+    const measuredWidth = textMeasureRef.current.offsetWidth;
+
+    if (measuredWidth > width) {
+      const requiredWidth = measuredWidth + 16; // 16px for padding
+      setPopperWidth(requiredWidth);
+    } else {
+      setPopperWidth(width); // Use default width
+    }
   };
 
   const handleMouseLeave = () => {
@@ -81,11 +100,27 @@ const ExpandableDataGridCell = React.memo((props) => {
       >
         {value}
       </Box>
+      {/*
+        Hidden span for measuring text width,
+        positioned offscreen so it doesn't interfere with layout
+      */}
+      <span
+        ref={textMeasureRef}
+        style={{
+          position: 'absolute',
+          top: '-9999px',
+          left: '-9999px',
+          visibility: 'none',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {value}
+      </span>
       {showPopper && (
         <Popper
           open={showFullCell && anchorEl !== null}
           anchorEl={anchorEl}
-          style={{ width, marginLeft: -17 }}
+          style={{ width: popperWidth, marginLeft: -17 }}
         >
           <Paper
             elevation={1}

--- a/ui/client/dagpipes/DagDatasetSelector.js
+++ b/ui/client/dagpipes/DagDatasetSelector.js
@@ -9,7 +9,7 @@ import format from 'date-fns/format';
 import Button from '@mui/material/Button';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
-import { DataGrid } from '@mui/x-data-grid';
+import { DataGrid, GridToolbarFilterButton, GridToolbarContainer } from '@mui/x-data-grid';
 
 import { useNCDatasets } from '../components/SWRHooks';
 import ExpandableDataGridCell from '../components/ExpandableDataGridCell';
@@ -24,12 +24,17 @@ const expandableCell = ({ value, colDef }) => (
 );
 
 const columns = [
-  { field: 'name', headerName: 'Name', width: 130 },
+  {
+    field: 'name',
+    headerName: 'Name',
+    renderCell: expandableCell,
+    width: 288,
+  },
   {
     field: 'id',
     headerName: 'ID',
     renderCell: expandableCell,
-    width: 288,
+    width: 130,
   },
   {
     field: 'created_at',
@@ -45,6 +50,7 @@ const columns = [
     description: 'This column has a value getter and is not sortable.',
     sortable: false,
     valueGetter: (params) => params.row?.maintainer.name,
+    renderCell: expandableCell,
     width: 160,
   },
   {
@@ -57,9 +63,16 @@ const columns = [
     field: 'fileData.raw.url',
     headerName: 'File Name',
     valueGetter: (params) => params.row?.fileData.raw.url,
+    renderCell: expandableCell,
     minWidth: 200,
   },
 ];
+
+const CustomToolbar = () => (
+  <GridToolbarContainer>
+    <GridToolbarFilterButton />
+  </GridToolbarContainer>
+);
 
 const DagDatasetSelector = () => {
   const { datasets, datasetsLoading, datasetsError } = useNCDatasets();
@@ -121,6 +134,8 @@ const DagDatasetSelector = () => {
         columns={columns}
         rows={datasets}
         onSelectionModelChange={handleRowSelection}
+        components={{ Toolbar: CustomToolbar }}
+        disableColumnMenu
       />
       <Button onClick={handleNext} sx={{ marginY: 1 }} disabled={!selectedDatasets.length}>
         Use these datasets


### PR DESCRIPTION
This adds a filter to the Data Modeling dataset selector, expands the name column, and improves the ExpandableDataGridCell component to expand to its widest word (where previously words wider than the parent cell would overflow the popper's paper). The Expandable improvement appears across the site. 

<img width="1273" alt="Screenshot 2024-01-17 at 11 03 34 AM" src="https://github.com/jataware/dojo/assets/2448578/cab94bb7-b36c-41a2-baa8-a0399e886865">
