### PR TITLE
UI/Data Modeler: sidebar overflow bugfix

### DIFF
--- a/ui/client/dagpipes/DragBar.js
+++ b/ui/client/dagpipes/DragBar.js
@@ -13,14 +13,14 @@ const useStyles = makeStyles()((theme) => ({
   sidebar: {
     display: 'flex',
     flexDirection: 'column',
-    gap: theme.spacing(2),
+    gap: theme.spacing(1.5),
     margin: theme.spacing(2),
     '& > button': {
       justifyContent: 'flex-start',
       gap: 0,
       padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
       cursor: 'default',
-      maxWidth: '200px',
+      maxWidth: '208px',
     }
   },
 }));
@@ -73,7 +73,12 @@ export default () => {
         onDragStart={onDragStart}
       />
       <DragButton label={NodeTitles.REDUCE_BY} name="sum" onDragStart={onDragStart} />
-      <DragButton label={NodeTitles.SCALAR_OPERATION} name="scalar_operation" onDragStart={onDragStart} />
+      <DragButton
+        label={NodeTitles.SCALAR_OPERATION}
+        name="scalar_operation"
+        onDragStart={onDragStart}
+        smallText
+      />
       <DragButton label={NodeTitles.SELECT_SLICE} name="select_slice" onDragStart={onDragStart} />
       <DragButton
         label={NodeTitles.MASK_TO_DISTANCE_FIELD}

--- a/ui/client/dagpipes/Footer.js
+++ b/ui/client/dagpipes/Footer.js
@@ -9,7 +9,6 @@ import { useSelector } from 'react-redux';
 
 const useStyles = makeStyles()((theme) => ({
   footer: {
-    gridArea: 'footer',
     borderTop: `1px solid ${theme.palette.grey[400]}`,
     height: '38px',
     backgroundColor: theme.palette.grey[200],
@@ -23,14 +22,14 @@ const useStyles = makeStyles()((theme) => ({
 }));
 
 const Footer = () => {
-  const { nodeCount, unsavedChanges } = useSelector((state) => state.dag);
+  const { nodeCount } = useSelector((state) => state.dag);
   const { classes } = useStyles();
 
   return (
-    <footer className={classes.footer}>
+    <div className={classes.footer}>
       <Typography variant="subtitle2" className={classes.text}>
         <span>
-          {nodeCount} node{nodeCount === 1 ? '' : 's'}. {unsavedChanges && (<span>Unsaved Changes.</span>)}
+          {nodeCount} node{nodeCount === 1 ? '' : 's'}
         </span>
         <Tooltip title="View Data Modeling documentation (opens new tab)">
           <Link
@@ -42,7 +41,7 @@ const Footer = () => {
           </Link>
         </Tooltip>
       </Typography>
-    </footer>
+    </div>
   );
 };
 

--- a/ui/client/dagpipes/ModelerResolution.js
+++ b/ui/client/dagpipes/ModelerResolution.js
@@ -111,7 +111,7 @@ const ModelerResolution = () => {
         helperText={
           error
             ? 'Please enter a valid number'
-            : 'Enter a single number for a square grid or two numbers separated by a comma for x,y coordinates'
+            : 'Enter one number for a square grid or two numbers (1,2) for x,y coords'
           }
       />
     </div>

--- a/ui/client/dagpipes/PipeEditor.js
+++ b/ui/client/dagpipes/PipeEditor.js
@@ -135,7 +135,6 @@ const useStyles = makeStyles()((theme) => ({
     // slightly more spacing than the height of the footer accounts for retina displays
     // otherwise we get a persistent scrollbar on retina
     height: 'calc(100% - 40px)',
-    minHeight: '620px',
   },
   fullWrapper: {
     position: 'absolute',
@@ -161,7 +160,8 @@ const useStyles = makeStyles()((theme) => ({
     margin: `${theme.spacing(4)} ${theme.spacing(2)} ${theme.spacing(2)}`,
   },
   wholeSidebar: {
-    width: '255px',
+    width: '275px',
+    overflow: 'auto',
   },
 }));
 


### PR DESCRIPTION
Fixes issue where data modeler sidebar overflowed into the footer when the page height was too short. Also a few other minor touch ups

Before:
<img width="533" alt="Screenshot 2024-02-22 at 6 21 03 PM" src="https://github.com/jataware/dojo/assets/2448578/aecbc1cc-45b0-48ce-a10b-167702d20038">

After:
<img width="309" alt="Screenshot 2024-02-22 at 6 21 36 PM" src="https://github.com/jataware/dojo/assets/2448578/822b5066-f76d-4f48-82ba-1deb1d663651">
