### PR TITLE
Bugfix: Model Geotiff Dataset Annotation Failure

### DIFF
--- a/tasks/tasks/tasks.py
+++ b/tasks/tasks/tasks.py
@@ -265,11 +265,18 @@ def model_output_analysis(context, model_id, fileurl, filepath):
             'excel_sheet': excel_file.sheet_names[0]
         }
     elif filepath.endswith('.tiff') or filepath.endswith('.tif'):
-        raster = rasterio.open(rasterio.io.MemoryFile(stream))
+        try:
+            with rasterio.open(rasterio.io.MemoryFile(stream)) as raster:
+                geotiff_band_count = raster.profile['count']
+        except Exception as e:
+            # Handle the exception
+            print(f"Error loading raster data: {e}")
+            geotiff_band_count = 0
+
         return {
             'file_uuid': file_uuid,
             'filetype': 'geotiff',
-            'geotiff_band_count': raster.profile['count'],
+            'geotiff_band_count': geotiff_band_count,
             'geotiff_band_type': "category",
             'geotiff_bands': {}
         }

--- a/ui/client/datasets/FileSelector.js
+++ b/ui/client/datasets/FileSelector.js
@@ -162,22 +162,28 @@ export const ExtraInput = ({
                   name="geotiff_value"
                   variant="outlined"
                   label="Enter dataset date"
-                  helperText="YYYY-MM-DD"
-                  onChange={(evt) => {
-                    const { value } = evt.target;
-                    setFileMetadata({ ...fileMetadata, geotiff_value: value });
-                  }}
+                  placeholder="YYYY-MM-DD"
+                  onChange={
+                    (event) => setFileMetadata({
+                      ...fileMetadata, geotiff_value: event.target.value
+                    })
+                  }
+                  required
                 />
                 <NullGeotiffTooltip>
-                  <TextField
-                    name="geotiff_Null_Val"
-                    variant="outlined"
-                    label="Geotiff Null Value"
-                    onChange={(evt) => {
-                      const { value } = evt.target;
-                      setFileMetadata({ ...fileMetadata, geotiff_null_value: value });
-                    }}
-                  />
+                  <span>
+                    <TextField
+                      name="geotiff_null_value"
+                      variant="outlined"
+                      label="Geotiff Null Value"
+                      onChange={
+                        (event) => setFileMetadata({
+                          ...fileMetadata, geotiff_null_value: event.target.value
+                        })
+                      }
+                      required
+                    />
+                  </span>
                 </NullGeotiffTooltip>
               </div>
 
@@ -268,40 +274,40 @@ export const ExtraInput = ({
           display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: '0.5em', rowGap: '0.5em', marginBottom: '1.1em'
         }}
         >
-          <FormAwareTextField
-            name="geotiff_Feature_Name"
+          <TextField
+            name="geotiff_value"
             variant="outlined"
             label="Geotiff Feature Name"
-            {...conditionalOnChange(
+            onChange={
               (event) => setFileMetadata({ ...fileMetadata, geotiff_value: event.target.value })
-            )}
+            }
             required
           />
           <NullGeotiffTooltip>
             <span>
-              <FormAwareTextField
-                name="geotiff_Null_Val"
+              <TextField
+                name="geotiff_null_value"
                 variant="outlined"
                 label="Geotiff Null Value"
-                {...conditionalOnChange(
+                onChange={
                   (event) => setFileMetadata({
                     ...fileMetadata, geotiff_null_value: event.target.value
                   })
-                )}
+                }
                 required
               />
             </span>
           </NullGeotiffTooltip>
-          <FormAwareTextField
+          <TextField
             name="geotiff_date_value"
             variant="outlined"
             label="Enter dataset date"
             placeholder="YYYY-MM-DD"
-            {...conditionalOnChange(
+            onChange={
               (event) => setFileMetadata({
                 ...fileMetadata, geotiff_date_value: event.target.value
               })
-            )}
+            }
             required
           />
         </div>

--- a/ui/client/datasets/FileSelector.js
+++ b/ui/client/datasets/FileSelector.js
@@ -37,9 +37,13 @@ const useStyles = makeStyles()((theme) => ({
       marginTop: theme.spacing(0.5)
     }
   },
-  geotiffInput: {
-    width: '100%',
-    borderRadius: 0,
+  geotiffInputWrapper: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    columnGap: '0.5em',
+    rowGap: '1em',
+    marginTop: '1em',
+    marginBottom: '1em'
   },
 }));
 
@@ -75,12 +79,13 @@ const NullGeotiffTooltip = ({ ...props }) => (
 );
 
 export const ExtraInput = ({
-  fileMetadata, setFileMetadata, formikControlled
+  fileMetadata, setFileMetadata
 }) => {
   // TODO This metadata is set on user file select etc, not on loading a previously
   // uploaded file. We'll check if we can populate
   // and display these prepopulated instead....
   // console.log('FileSelector.js - ExtraInput - fileMetadata:', fileMetadata);
+  const { classes } = useStyles();
   if (!fileMetadata.filetype) {
     return null;
   }
@@ -99,6 +104,10 @@ export const ExtraInput = ({
     }
     setFileMetadata({ ...fileMetadata, geotiff_bands });
   };
+
+  // TODO: Include this in the formik form (or make a new form?) so it can have errors
+  // and be required etc - currently problematic for ModelOutput with how it saves to formik.values
+  // instead of metadata
 
   // Don't include the onChange prop if we have the formikControlled prop
   // or formik's onChange prop will get overwritten in FormikAwareTextField
@@ -174,14 +183,7 @@ export const ExtraInput = ({
 
           {fileMetadata.geotiff_band_type === 'category' && (
             <>
-              <div style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                columnGap: '0.5em',
-                rowGap: '0.5em',
-                marginBottom: '0.5em',
-              }}
-              >
+              <div className={classes.geotiffInputWrapper}>
                 <GeotiffTextField
                   name="geotiff_value"
                   label="Dataset date"
@@ -203,14 +205,7 @@ export const ExtraInput = ({
                 </NullGeotiffTooltip>
               </div>
 
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: '1fr 1fr',
-                  columnGap: '0.5em',
-                  rowGap: '0.5em',
-                }}
-              >
+              <div className={classes.geotiffInputWrapper}>
                 {/* generate numbered TextField input for each band in the geotiff for labeling */}
                 {Array.from(Array(fileMetadata.geotiff_band_count).keys())
                   .map((i) => {
@@ -229,17 +224,13 @@ export const ExtraInput = ({
           )}
           {fileMetadata.geotiff_band_type === 'temporal' && (
           <>
-            <div style={{
-              display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: '0.5em', rowGap: '0.5em', marginBottom: '1.1em'
-            }}
-            >
+            <div className={classes.geotiffInputWrapper}>
               <GeotiffTextField
                 name="geotiff_feature_name"
                 label="Enter feature name"
-                onChange={(evt) => {
-                  const { value } = evt.target;
-                  setFileMetadata({ ...fileMetadata, geotiff_value: value });
-                }}
+                onChange={(event) => setFileMetadata({
+                  ...fileMetadata, geotiff_value: event.target.value
+                })}
               />
               <NullGeotiffTooltip>
                 <GeotiffTextField
@@ -255,11 +246,7 @@ export const ExtraInput = ({
             <div>
               <Typography variant="caption">Suggested format: YYYY-MM-DD</Typography>
             </div>
-            <div
-              style={{
-                display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: '0.5em', rowGap: '0.5em'
-              }}
-            >
+            <div className={classes.geotiffInputWrapper}>
               {/* generate numbered TextField input for each band in the geotiff for labeling */}
               {Array.from(Array(fileMetadata.geotiff_band_count).keys()).map((i) => {
                 const band_num = i + 1;
@@ -281,10 +268,7 @@ export const ExtraInput = ({
     }
     if (fileMetadata.geotiff_band_count === 1) {
       return (
-        <div style={{
-          display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: '0.5em', rowGap: '0.5em', marginBottom: '1.1em'
-        }}
-        >
+        <div className={classes.geotiffInputWrapper}>
           <GeotiffTextField
             name="geotiff_value"
             label="Geotiff Feature Name"

--- a/ui/client/datasets/FileSelector.js
+++ b/ui/client/datasets/FileSelector.js
@@ -14,7 +14,6 @@ import isFunction from 'lodash/isFunction';
 
 import { makeStyles } from 'tss-react/mui';
 
-import { FormAwareTextField } from './FormFields';
 import { matchFileNameExtension } from '../utils';
 import { getBrandName } from '../components/uiComponents/Branding';
 
@@ -37,8 +36,31 @@ const useStyles = makeStyles()((theme) => ({
     '& button': {
       marginTop: theme.spacing(0.5)
     }
-  }
+  },
+  geotiffInput: {
+    width: '100%',
+    borderRadius: 0,
+  },
 }));
+
+const GeotiffTextField = ({
+  name, label, placeholder, onChange, ...props
+}) => (
+  <TextField
+    name={name}
+    variant="outlined"
+    label={label}
+    placeholder={placeholder}
+    onChange={onChange}
+    required
+    fullWidth
+    InputProps={{
+      style: { borderRadius: 0 },
+    }}
+    InputLabelProps={{ shrink: true }}
+    {...props}
+  />
+);
 
 const NullGeotiffTooltip = ({ ...props }) => (
   <Tooltip
@@ -59,7 +81,6 @@ export const ExtraInput = ({
   // uploaded file. We'll check if we can populate
   // and display these prepopulated instead....
   // console.log('FileSelector.js - ExtraInput - fileMetadata:', fileMetadata);
-
   if (!fileMetadata.filetype) {
     return null;
   }
@@ -81,13 +102,13 @@ export const ExtraInput = ({
 
   // Don't include the onChange prop if we have the formikControlled prop
   // or formik's onChange prop will get overwritten in FormikAwareTextField
-  const conditionalOnChange = (handler) => (
-    formikControlled ? {} : {
-      onChange: (event) => {
-        handler(event);
-      }
-    }
-  );
+  // const conditionalOnChange = (handler) => (
+  //   formikControlled ? {} : {
+  //     onChange: (event) => {
+  //       handler(event);
+  //     }
+  //   }
+  // );
 
   if (fileMetadata.filetype === 'excel') {
     const label = 'Sheet selection';
@@ -142,10 +163,9 @@ export const ExtraInput = ({
               variant="outlined"
               margin="dense"
               value={fileMetadata.geotiff_band_type}
-              onChange={(evt) => {
-                const { value } = evt.target;
-                setFileMetadata({ ...fileMetadata, geotiff_band_type: value, geotiff_bands: {} });
-              }}
+              onChange={(event) => setFileMetadata({
+                ...fileMetadata, geotiff_band_type: event.target.value, geotiff_bands: {}
+              })}
             >
               <MenuItem value="category">category</MenuItem>
               <MenuItem value="temporal">temporal</MenuItem>
@@ -155,33 +175,29 @@ export const ExtraInput = ({
           {fileMetadata.geotiff_band_type === 'category' && (
             <>
               <div style={{
-                display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: '0.5em', rowGap: '0.5em',
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                columnGap: '0.5em',
+                rowGap: '0.5em',
+                marginBottom: '0.5em',
               }}
               >
-                <TextField
+                <GeotiffTextField
                   name="geotiff_value"
-                  variant="outlined"
-                  label="Enter dataset date"
+                  label="Dataset date"
                   placeholder="YYYY-MM-DD"
-                  onChange={
-                    (event) => setFileMetadata({
-                      ...fileMetadata, geotiff_value: event.target.value
-                    })
-                  }
-                  required
+                  onChange={(event) => setFileMetadata({
+                    ...fileMetadata, geotiff_value: event.target.value
+                  })}
                 />
                 <NullGeotiffTooltip>
                   <span>
-                    <TextField
+                    <GeotiffTextField
                       name="geotiff_null_value"
-                      variant="outlined"
                       label="Geotiff Null Value"
-                      onChange={
-                        (event) => setFileMetadata({
-                          ...fileMetadata, geotiff_null_value: event.target.value
-                        })
-                      }
-                      required
+                      onChange={(event) => setFileMetadata({
+                        ...fileMetadata, geotiff_null_value: event.target.value
+                      })}
                     />
                   </span>
                 </NullGeotiffTooltip>
@@ -200,10 +216,9 @@ export const ExtraInput = ({
                   .map((i) => {
                     const band_num = i + 1;
                     return (
-                      <TextField
+                      <GeotiffTextField
                         key={`band_${band_num}`}
                         name="bands"
-                        variant="outlined"
                         label={`Band ${band_num} Name`}
                         onChange={(evt) => setBand(evt, band_num)}
                       />
@@ -218,9 +233,8 @@ export const ExtraInput = ({
               display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: '0.5em', rowGap: '0.5em', marginBottom: '1.1em'
             }}
             >
-              <TextField
+              <GeotiffTextField
                 name="geotiff_feature_name"
-                variant="outlined"
                 label="Enter feature name"
                 onChange={(evt) => {
                   const { value } = evt.target;
@@ -228,14 +242,12 @@ export const ExtraInput = ({
                 }}
               />
               <NullGeotiffTooltip>
-                <TextField
+                <GeotiffTextField
                   name="geotiff_Null_Val"
-                  variant="outlined"
                   label="Geotiff Null Value"
-                  onChange={(evt) => {
-                    const { value } = evt.target;
-                    setFileMetadata({ ...fileMetadata, geotiff_null_value: value });
-                  }}
+                  onChange={(event) => setFileMetadata({
+                    ...fileMetadata, geotiff_null_value: event.target.value
+                  })}
                 />
               </NullGeotiffTooltip>
             </div>
@@ -252,11 +264,10 @@ export const ExtraInput = ({
               {Array.from(Array(fileMetadata.geotiff_band_count).keys()).map((i) => {
                 const band_num = i + 1;
                 return (
-                  <TextField
+                  <GeotiffTextField
                     key={`band_${band_num}`}
                     bandnum={band_num}
                     name="bands"
-                    variant="outlined"
                     label={`Band ${band_num} Date`}
                     onChange={(evt) => setBand(evt, band_num)}
                   />
@@ -274,33 +285,28 @@ export const ExtraInput = ({
           display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: '0.5em', rowGap: '0.5em', marginBottom: '1.1em'
         }}
         >
-          <TextField
+          <GeotiffTextField
             name="geotiff_value"
-            variant="outlined"
             label="Geotiff Feature Name"
             onChange={
               (event) => setFileMetadata({ ...fileMetadata, geotiff_value: event.target.value })
             }
-            required
           />
           <NullGeotiffTooltip>
             <span>
-              <TextField
+              <GeotiffTextField
                 name="geotiff_null_value"
-                variant="outlined"
                 label="Geotiff Null Value"
                 onChange={
                   (event) => setFileMetadata({
                     ...fileMetadata, geotiff_null_value: event.target.value
                   })
                 }
-                required
               />
             </span>
           </NullGeotiffTooltip>
-          <TextField
+          <GeotiffTextField
             name="geotiff_date_value"
-            variant="outlined"
             label="Enter dataset date"
             placeholder="YYYY-MM-DD"
             onChange={
@@ -308,7 +314,6 @@ export const ExtraInput = ({
                 ...fileMetadata, geotiff_date_value: event.target.value
               })
             }
-            required
           />
         </div>
       );

--- a/ui/client/datasets/FileSelector.js
+++ b/ui/client/datasets/FileSelector.js
@@ -3,14 +3,18 @@ import { useField } from 'formik';
 import * as XLSX from 'xlsx/xlsx.mjs';
 import * as GeoTiff from 'geotiff';
 
+import get from 'lodash/get';
+import isFunction from 'lodash/isFunction';
+
 import Autocomplete from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
-import { Tooltip, Typography } from '@mui/material';
-import get from 'lodash/get';
-import isFunction from 'lodash/isFunction';
+import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
 
 import { makeStyles } from 'tss-react/mui';
 
@@ -86,7 +90,27 @@ export const ExtraInput = ({
   // and display these prepopulated instead....
   // console.log('FileSelector.js - ExtraInput - fileMetadata:', fileMetadata);
   const { classes } = useStyles();
+
   if (!fileMetadata.filetype) {
+    if (!fileMetadata.file_uuid) {
+      // the metadata hasn't loaded, so show a spinner until it loads
+      return (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            color: 'grey.600',
+            marginTop: 1,
+          }}
+        >
+          <Typography variant="h6" gutterBottom>Loading File Type...</Typography>
+          <CircularProgress size={24} color="inherit" />
+        </Box>
+      );
+    }
+
+    // the metadata has loaded and we still don't have the filetype, so nothing to show
     return null;
   }
 

--- a/ui/client/datasets/FileSelector.js
+++ b/ui/client/datasets/FileSelector.js
@@ -14,6 +14,7 @@ import isFunction from 'lodash/isFunction';
 
 import { makeStyles } from 'tss-react/mui';
 
+import { FormAwareTextField } from './FormFields';
 import { matchFileNameExtension } from '../utils';
 import { getBrandName } from '../components/uiComponents/Branding';
 
@@ -52,7 +53,7 @@ const NullGeotiffTooltip = ({ ...props }) => (
 );
 
 export const ExtraInput = ({
-  fileMetadata, setFileMetadata
+  fileMetadata, setFileMetadata, formikControlled
 }) => {
   // TODO This metadata is set on user file select etc, not on loading a previously
   // uploaded file. We'll check if we can populate
@@ -77,6 +78,16 @@ export const ExtraInput = ({
     }
     setFileMetadata({ ...fileMetadata, geotiff_bands });
   };
+
+  // Don't include the onChange prop if we have the formikControlled prop
+  // or formik's onChange prop will get overwritten in FormikAwareTextField
+  const conditionalOnChange = (handler) => (
+    formikControlled ? {} : {
+      onChange: (event) => {
+        handler(event);
+      }
+    }
+  );
 
   if (fileMetadata.filetype === 'excel') {
     const label = 'Sheet selection';
@@ -257,36 +268,41 @@ export const ExtraInput = ({
           display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: '0.5em', rowGap: '0.5em', marginBottom: '1.1em'
         }}
         >
-          <TextField
+          <FormAwareTextField
             name="geotiff_Feature_Name"
             variant="outlined"
             label="Geotiff Feature Name"
-            onChange={(evt) => {
-              const { value } = evt.target;
-              setFileMetadata({ ...fileMetadata, geotiff_value: value });
-            }}
+            {...conditionalOnChange(
+              (event) => setFileMetadata({ ...fileMetadata, geotiff_value: event.target.value })
+            )}
+            required
           />
           <NullGeotiffTooltip>
-            <TextField
-              name="geotiff_Null_Val"
-              variant="outlined"
-              label="Geotiff Null Value"
-              helperText=""
-              onChange={(evt) => {
-                const { value } = evt.target;
-                setFileMetadata({ ...fileMetadata, geotiff_null_value: value });
-              }}
-            />
+            <span>
+              <FormAwareTextField
+                name="geotiff_Null_Val"
+                variant="outlined"
+                label="Geotiff Null Value"
+                {...conditionalOnChange(
+                  (event) => setFileMetadata({
+                    ...fileMetadata, geotiff_null_value: event.target.value
+                  })
+                )}
+                required
+              />
+            </span>
           </NullGeotiffTooltip>
-          <TextField
+          <FormAwareTextField
             name="geotiff_date_value"
             variant="outlined"
             label="Enter dataset date"
-            helperText="YYYY-MM-DD"
-            onChange={(evt) => {
-              const { value } = evt.target;
-              setFileMetadata({ ...fileMetadata, geotiff_date_value: value });
-            }}
+            placeholder="YYYY-MM-DD"
+            {...conditionalOnChange(
+              (event) => setFileMetadata({
+                ...fileMetadata, geotiff_date_value: event.target.value
+              })
+            )}
+            required
           />
         </div>
       );

--- a/ui/client/datasets/FileSelector.js
+++ b/ui/client/datasets/FileSelector.js
@@ -5,6 +5,7 @@ import * as GeoTiff from 'geotiff';
 
 import get from 'lodash/get';
 import isFunction from 'lodash/isFunction';
+import isEmpty from 'lodash/isEmpty';
 
 import Autocomplete from '@mui/material/Autocomplete';
 import Button from '@mui/material/Button';
@@ -551,11 +552,14 @@ export const FileSelector = ((allProps) => {
           {message}
         </div>
       )}
-      <ExtraInput
-        formik={formik}
-        fileMetadata={fileMetadata}
-        setFileMetadata={setFileMetadata}
-      />
+      {/* only load ExtraInput after the file upload has started (in Register.js) */}
+      {!isEmpty(fileMetadata) && (
+        <ExtraInput
+          formik={formik}
+          fileMetadata={fileMetadata}
+          setFileMetadata={setFileMetadata}
+        />
+      )}
     </div>
   );
 });

--- a/ui/client/datasets/FileSelector.js
+++ b/ui/client/datasets/FileSelector.js
@@ -220,7 +220,7 @@ export const ExtraInput = ({
                 <NullGeotiffTooltip>
                   <span>
                     <GeotiffTextField
-                      name="geotiff_null_value"
+                      name="geotiff_Null_Val"
                       label="Geotiff Null Value"
                       onChange={(event) => setFileMetadata({
                         ...fileMetadata, geotiff_null_value: event.target.value
@@ -295,7 +295,7 @@ export const ExtraInput = ({
       return (
         <div className={classes.geotiffInputWrapper}>
           <GeotiffTextField
-            name="geotiff_value"
+            name="geotiff_Feature_Name"
             label="Geotiff Feature Name"
             onChange={
               (event) => setFileMetadata({ ...fileMetadata, geotiff_value: event.target.value })
@@ -304,7 +304,7 @@ export const ExtraInput = ({
           <NullGeotiffTooltip>
             <span>
               <GeotiffTextField
-                name="geotiff_null_value"
+                name="geotiff_Null_Val"
                 label="Geotiff Null Value"
                 onChange={
                   (event) => setFileMetadata({

--- a/ui/client/datasets/ModelOutput.js
+++ b/ui/client/datasets/ModelOutput.js
@@ -304,7 +304,6 @@ export default ({
       >
         {(formik) => (
           <Form>
-
             <Grid
               container
               spacing={4}

--- a/ui/client/datasets/ModelOutput.js
+++ b/ui/client/datasets/ModelOutput.js
@@ -40,6 +40,10 @@ const baseSchema = yup.object({
     .required('Please enter a description.'),
 });
 
+// TODO: this is for including the geotiff subform in the yup schema
+// this works, but the subform saves into formik.values instead of the metadata
+// we either need a new form & to pass up a value to disable next & etc
+// or to pull out the geotiff subform values & put them in metadata in formik.onsubmit
 // const geotiffSchema = (fileMetadata) => {
 //   let schema = {};
 
@@ -52,9 +56,9 @@ const baseSchema = yup.object({
 //         geotiff_null_value: yup.string().required('Enter Geotiff Null Value.'),
 //       };
 
-//       // for (let i = 0; i < fileMetadata.geotiff_band_count; i++) {
-//       //   schema[`band_${i + 1}_name`] = yup.string().required(`Band ${i + 1} Name is required.`);
-//       // }
+//       for (let i = 0; i < fileMetadata.geotiff_band_count; i++) {
+//         schema[`band_${i + 1}_name`] = yup.string().required(`Band ${i + 1} Name is required.`);
+//       }
 //     } else if (fileMetadata.geotiff_band_type === 'temporal') {
 //       // temporal specific validation
 //       schema = {
@@ -62,9 +66,9 @@ const baseSchema = yup.object({
 //         geotiff_null_value: yup.string().required('Enter Geotiff Null Value.'),
 //       };
 
-//       // for (let i = 0; i < fileMetadata.geotiff_band_count; i++) {
-//       //   schema[`band_${i + 1}_date`] = yup.string().required(`Band ${i + 1} Date is required.`);
-//       // }
+//       for (let i = 0; i < fileMetadata.geotiff_band_count; i++) {
+//       schema[`band_${i + 1}_date`] = yup.string().required(`Band ${i + 1} Date is required.`);
+//       }
 //     }
 //   } else if (fileMetadata.geotiff_band_count === 1) {
 //     // Validation for single band
@@ -78,7 +82,9 @@ const baseSchema = yup.object({
 //   return yup.object().shape(schema);
 // };
 
+// eslint-disable-next-line no-unused-vars
 const getDynamicValidationSchema = (fileMetadata) => {
+  // eslint-disable-next-line prefer-const
   let schema = baseSchema;
 
   // if (fileMetadata.filetype === 'geotiff') {
@@ -184,6 +190,8 @@ export default ({
     filename: null,
   });
   const [loading, setLoading] = useState(false);
+  // TODO: this is used for the geotiff subform - otherwise it could just be unchanging baseSchema
+  // eslint-disable-next-line no-unused-vars
   const [validationSchema, setValidationSchema] = useState(baseSchema);
 
   const { classes } = useStyles();
@@ -244,11 +252,12 @@ export default ({
     annotations,
   ]);
 
-  useEffect(() => {
-    // Update form schema based on fileMetadata
-    const newValidationSchema = getDynamicValidationSchema(fileMetadata);
-    setValidationSchema(newValidationSchema);
-  }, [fileMetadata]);
+  // TODO: this is used for the geotiff subform, which loads when the metadata comes in
+  // useEffect(() => {
+  //   // Update form schema based on fileMetadata
+  //   const newValidationSchema = getDynamicValidationSchema(fileMetadata);
+  //   setValidationSchema(newValidationSchema);
+  // }, [fileMetadata]);
 
   const defaultValues = {
     name: datasetInfo?.name || '',

--- a/ui/client/datasets/ModelOutput.js
+++ b/ui/client/datasets/ModelOutput.js
@@ -40,50 +40,50 @@ const baseSchema = yup.object({
     .required('Please enter a description.'),
 });
 
-const geotiffSchema = (fileMetadata) => {
-  let schema = {};
+// const geotiffSchema = (fileMetadata) => {
+//   let schema = {};
 
-  if (fileMetadata.geotiff_band_count > 1) {
-    // Validation for multiple bands
-    if (fileMetadata.geotiff_band_type === 'category') {
-      // category specific validation
-      schema = {
-        geotiff_value: yup.string().required('Enter dataset date.'),
-        geotiff_null_value: yup.string().required('Enter Geotiff Null Value.'),
-      };
+//   if (fileMetadata.geotiff_band_count > 1) {
+//     // Validation for multiple bands
+//     if (fileMetadata.geotiff_band_type === 'category') {
+//       // category specific validation
+//       schema = {
+//         geotiff_value: yup.string().required('Enter dataset date.'),
+//         geotiff_null_value: yup.string().required('Enter Geotiff Null Value.'),
+//       };
 
-      for (let i = 0; i < fileMetadata.geotiff_band_count; i++) {
-        schema[`band_${i + 1}_name`] = yup.string().required(`Band ${i + 1} Name is required.`);
-      }
-    } else if (fileMetadata.geotiff_band_type === 'temporal') {
-      // temporal specific validation
-      schema = {
-        geotiff_feature_name: yup.string().required('Enter feature name.'),
-        geotiff_null_value: yup.string().required('Enter Geotiff Null Value.'),
-      };
+//       // for (let i = 0; i < fileMetadata.geotiff_band_count; i++) {
+//       //   schema[`band_${i + 1}_name`] = yup.string().required(`Band ${i + 1} Name is required.`);
+//       // }
+//     } else if (fileMetadata.geotiff_band_type === 'temporal') {
+//       // temporal specific validation
+//       schema = {
+//         geotiff_feature_name: yup.string().required('Enter feature name.'),
+//         geotiff_null_value: yup.string().required('Enter Geotiff Null Value.'),
+//       };
 
-      for (let i = 0; i < fileMetadata.geotiff_band_count; i++) {
-        schema[`band_${i + 1}_date`] = yup.string().required(`Band ${i + 1} Date is required.`);
-      }
-    }
-  } else if (fileMetadata.geotiff_band_count === 1) {
-    // Validation for single band
-    schema = {
-      geotiff_Feature_Name: yup.string().required('Enter Geotiff Feature Name.'),
-      geotiff_Null_Val: yup.string().required('Enter Geotiff Null Value.'),
-      geotiff_date_value: yup.string().required('Enter dataset date.'),
-    };
-  }
+//       // for (let i = 0; i < fileMetadata.geotiff_band_count; i++) {
+//       //   schema[`band_${i + 1}_date`] = yup.string().required(`Band ${i + 1} Date is required.`);
+//       // }
+//     }
+//   } else if (fileMetadata.geotiff_band_count === 1) {
+//     // Validation for single band
+//     schema = {
+//       geotiff_value: yup.string().required('Enter Geotiff Feature Name.'),
+//       geotiff_null_value: yup.string().required('Enter Geotiff Null Value.'),
+//       geotiff_date_value: yup.string().required('Enter dataset date.'),
+//     };
+//   }
 
-  return yup.object().shape(schema);
-};
+//   return yup.object().shape(schema);
+// };
 
 const getDynamicValidationSchema = (fileMetadata) => {
   let schema = baseSchema;
 
-  if (fileMetadata.filetype === 'geotiff') {
-    schema = schema.concat(geotiffSchema(fileMetadata));
-  }
+  // if (fileMetadata.filetype === 'geotiff') {
+  //   schema = schema.concat(geotiffSchema(fileMetadata));
+  // }
 
   return schema;
 };

--- a/ui/client/datasets/ModelOutput.js
+++ b/ui/client/datasets/ModelOutput.js
@@ -159,7 +159,8 @@ const BaseData = ({
       formik={formik}
       fileMetadata={fileMetadata}
       setFileMetadata={setFileMetadata}
-      formikControlled
+      // TODO: prop not yet in use to let this know to use formik for onChange
+      // formikControlled
     />
   </Section>
 );

--- a/ui/client/datasets/ModelOutput.js
+++ b/ui/client/datasets/ModelOutput.js
@@ -227,6 +227,10 @@ export default ({
           filepath: props?.file_path || '',
         });
       });
+    } else if (datasetInfo.id && !fileMetadata.file_uuid && annotations?.metadata?.file_uuid) {
+      // we've fetched the datasetInfo, but haven't set the file_uuid, so the user has hit 'back'
+      // so update the local fileMetadata
+      setFileMetadata({ ...annotations.metadata });
     }
   }, [
     datasetInfo,
@@ -236,7 +240,8 @@ export default ({
     props?.request_path,
     setAnnotations,
     setDatasetInfo,
-    loading
+    loading,
+    annotations,
   ]);
 
   useEffect(() => {

--- a/ui/client/datasets/RegistrationStepper.js
+++ b/ui/client/datasets/RegistrationStepper.js
@@ -137,7 +137,6 @@ function getUpdateRawFileName(uploadedRawFileNames) {
 const InnerStepper = ({ match, updateLocation, ...props }) => {
   const { flowslug, step, datasetId } = match?.params;
   const shouldUpdateLocation = updateLocation === undefined ? true : Boolean(updateLocation);
-
   const history = useHistory();
   const { classes } = useStyles();
   const location = useLocation();


### PR DESCRIPTION
This PR fixes the immediate failure of geotiff dataset annotation when in a running model (the terminal emulator). The primary issue was an issue with `rasterio` failing to initialize in the `model_output_analysis` step. Ensuring it's loaded properly and providing a fallback fixes this. 

I also disabled the `NEXT` button until the geotiff sub-form loads (and added a loading spinner to show that something is happening). I spent some time attempting to make this part of the form properly required, but due to the complexity of the various moving pieces, I decided to leave it as is for now. We can circle back on this if we decide it's worth the time investment. 