### PR TITLE
Fix storage issues

### DIFF
--- a/tasks/tasks/settings.py
+++ b/tasks/tasks/settings.py
@@ -1,5 +1,5 @@
 from pydantic_settings import BaseSettings
-
+from typing import Optional
 
 class Settings(BaseSettings):
 
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
 
     TERMINAL_ENDPOINT: str
 
-    STORAGE_HOST: str = None
+    STORAGE_HOST: Optional[str] = ""
     AWS_ACCESS_KEY_ID: str = ""
     AWS_SECRET_ACCESS_KEY: str = ""
 

--- a/tasks/tasks/utils.py
+++ b/tasks/tasks/utils.py
@@ -16,7 +16,7 @@ from settings import settings
 
 s3 = boto3.client(
     "s3",
-    endpoint_url=settings.STORAGE_HOST,
+    endpoint_url=settings.STORAGE_HOST if settings.STORAGE_HOST else None,
     aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
     aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
     aws_session_token=None,


### PR DESCRIPTION
Things worked locally since in the `envfile` we were setting `STORAGE_HOST` to Minio. But in production we didn't set that so Boto would just see the host as `None` and route things to S3. That worked fine until Pydantic was updated; now you can't use `None` as we were in the `tasks/settings.py`. This addresses the problems and ensures things work in prod.