### PR TITLE
Fixes for multiple rq workers with different pydantic versions

### DIFF
--- a/tasks/tasks/requirements.txt
+++ b/tasks/tasks/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.24.8
 elasticsearch==7.12.0
 cartwright==0.0.3
 h5netcdf==1.0.1
-numpy==1.24
+numpy==1.22
 netCDF4==1.5.3
 matplotlib==3.5.2
 GDAL==3.2.2
@@ -12,15 +12,11 @@ python-dateutil==2.8.2
 raster2xyz==0.1.3
 requests==2.28.1
 rq==1.11.0
-# scipy==1.6.2
+scipy==1.6.2
 # torchvision==0.16.1  # Imported in unused anomaly detection
-tqdm
+tqdm==4.64.0
 xarray==0.19.0
 h5py==2.10.0
 rasterio<1.3
 urllib3<2
 flowcast>=0.3.5
-tiktoken
-pypdf
-ocrmypdf==14.0.2
-# jatarag==0.1.5

--- a/tasks/tasks/settings.py
+++ b/tasks/tasks/settings.py
@@ -1,4 +1,7 @@
-from pydantic_settings import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:
+    from pydantic import BaseSettings
 from typing import Optional
 
 class Settings(BaseSettings):


### PR DESCRIPTION
Need to test with RAG worker but the core problem really is Cartwright has a pinned version of pydantic which relies on things that break in newer versions of pydantic.