### PR TITLE
Track user chat sessions in Redis

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -46,4 +46,4 @@ idna==2.10
 sniffio==1.3.0
 httpcore==1.0.5
 httpx==0.27.0
-jatarag==0.1.5
+jatarag==0.1.8

--- a/ui/client/components/aiAssistant/AIAssistant.js
+++ b/ui/client/components/aiAssistant/AIAssistant.js
@@ -29,6 +29,8 @@ import { drawerWidth } from '../Sidebar';
 import { pageSlideAnimation } from '../NavBar';
 import usePageTitle from '../uiComponents/usePageTitle';
 
+import { v4 as uuidv4 } from 'uuid';
+
 const useStyles = makeStyles()((theme) => ({
   header: {
     padding: `${theme.spacing(4)} 0`,
@@ -55,6 +57,30 @@ const useStyles = makeStyles()((theme) => ({
     alignItems: 'center',
   },
 }));
+
+// Function to generate a user token
+const generateChatUserToken = () => {
+  // Generate a unique token using uuid
+  return uuidv4();
+};
+
+// Function to store the token in localStorage
+const storeChatUserToken = (token) => {
+  localStorage.setItem('chatuserToken', token);
+};
+
+// Function to retrieve the token from localStorage
+const getChatUserToken = () => {
+  return localStorage.getItem('chatuserToken');
+};
+
+// Ensure a token is generated and stored if not already present
+if (!getChatUserToken()) {
+  const newToken = generateChatUserToken();
+  storeChatUserToken(newToken);
+}
+
+const chatuserToken = getChatUserToken();
 
 const isScrolledToBottom = (buffer = 0) => {
   const totalPageHeight = document.body.scrollHeight;
@@ -130,10 +156,10 @@ const AIAssistant = () => {
       });
     };
 
-    const knowledgeEndpoint = process.env.NODE_ENV === 'production' ? 'chat' : 'mock-chat';
+    const knowledgeEndpoint = 'chat' //process.env.NODE_ENV === 'production' ? 'chat' : 'mock-chat';
 
     const assistantConnection = new EventSource(
-      `/api/dojo/knowledge/${knowledgeEndpoint}?query=${searchPhrase}`
+      `/api/dojo/knowledge/${knowledgeEndpoint}?query=${searchPhrase}&chat_user_token=${encodeURIComponent(chatuserToken)}`
     );
 
     // the main text


### PR DESCRIPTION
# Main Changes

The goal of this PR is twofold:
1. If a user navigates off the page and returns, their is some history of their chat
2. Two users chat contexts will no longer intermingle. `User B` cannot ask: "What did I last ask you?" to see `User A`'s query.

This is accomplished by:

1. Adding a `chatuserToken` to the user's `localstorage`
5. Pass in that token to `/knowledge/chat` as a query parameter
6. Fetch the message history from Redis for that `chatuserToken`
7. Instantiate a new `librarian` with those `messages` as history
8. Respond to the user's query
9. Overwrite any stored messages for that `chatuserToken` in Redis with a 24 hour TTL

This seems to work well enough but I am concerned about a couple things:

1. Is using `localstorage` the right way to do this? In production I assume we'd want to tie things to the username--so this feels a bit hacky. But I don't think we need real persistence of these chats.
2. If the chats get very long in a given session this could blow up Redis. `messages` might need to be truncated somehow.

@ccjoel I'm curious your take on 1) and @david-andrew I'm curious your thoughts on 2).

## Secondary Changes

This PR also adds a fuzzy and wildcard search over titles. This enables the agent to do things like take a user query:

```
Can you compare the World Situation Report's findings with that of the UN contributions under paris agreement?
```

and correctly retrieve two documents:

1. `World Economic Situation and Prospects 2024` 
2. `Nationally determined contributions under the Paris Agreement`

This may be sufficient without needing to implement further semantic search over titles.