### PR TITLE
fix data modeling errors not being logged

### DIFF
--- a/tasks/tasks/data_modeling.py
+++ b/tasks/tasks/data_modeling.py
@@ -366,11 +366,12 @@ def run_flowcast_job(context:FlowcastContext) -> dict:
     except Exception as e:
         # print exception with stack trace
         import traceback
-        traceback.print_exc()
+        traceback_str = traceback.format_exc()
         print(f'Flowcast job failed', flush=True)
+        print(traceback_str, flush=True)
         return {
             'message': 'error running flowcast job',
-            'error': str(e)
+            'error': f'{e}\n{traceback_str}'
         }
 
 def unhandled_run_flowcast_job(context:FlowcastContext) -> dict:

--- a/tasks/tasks/requirements.txt
+++ b/tasks/tasks/requirements.txt
@@ -5,6 +5,7 @@ h5netcdf==1.0.1
 numpy==1.22
 netCDF4==1.5.3
 matplotlib==3.5.2
+setuptools==57.5.0
 GDAL==3.2.2
 elwood==0.1.4
 pandas==1.5.3
@@ -12,11 +13,11 @@ python-dateutil==2.8.2
 raster2xyz==0.1.3
 requests==2.28.1
 rq==1.11.0
-scipy==1.6.2
+scipy==1.9.3
 # torchvision==0.16.1  # Imported in unused anomaly detection
 tqdm==4.64.0
 xarray==0.19.0
 h5py==2.10.0
 rasterio<1.3
 urllib3<2
-flowcast>=0.3.5
+flowcast>=0.3.8


### PR DESCRIPTION
Fixes data modeling not logging exceptions that occur during execution

for some reason `traceback.print_exc()` no longer prints to the container logs, so switching to a regular print statement so that errors are logged properly