### PR TITLE
Data modeling validation + node preview

### DIFF
--- a/api/src/data.py
+++ b/api/src/data.py
@@ -31,7 +31,7 @@ redis = Redis(
 q = Queue(connection=redis, default_timeout=-1)
 # Create queues
 default_queue = q
-datamodeling_queue = Queue('datamodeling', connection=Redis())
+datamodeling_queue = Queue('datamodeling', connection=redis)
 
 def get_queue(queue_name):
     if queue_name == 'datamodeling':
@@ -227,8 +227,13 @@ def job_status(uuid: str, job_string: str, queue_name: str = "default"):
     If a job exists, returns the full job data.
     """
     job_id = f"{uuid}_{job_string}"
+    if "data_modeling" in job_string:
+        queue_name = "datamodeling"
+    else:
+        queue_name = "default"
+    q_ = get_queue(queue_name)    
 
-    job = q.fetch_job(job_id)
+    job = q_.fetch_job(job_id)
 
     # It is None, since no job exists
     if not job:

--- a/docker-compose.build-override.yaml
+++ b/docker-compose.build-override.yaml
@@ -210,7 +210,16 @@ services:
     depends_on:
       - redis
     volumes:
-      - dataset-storage:/datasets      
+      - dataset-storage:/datasets     
+  rqworker-datamodeling:
+    env_file:
+      - envfile
+    networks:
+      - dojo-stack
+    depends_on:
+      - redis
+    volumes:
+      - dataset-storage:/datasets       
   perm-fixer:
     build:
       context: ./perm-fixer/

--- a/tasks/Dockerfile
+++ b/tasks/Dockerfile
@@ -7,9 +7,11 @@ RUN apt-get update &&\
 
 RUN apt install --no-install-recommends -y libreoffice-writer libreoffice-impress    
 
+RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_0.feather.zip
 RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_2.feather.zip
 RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_3.feather.zip
 RUN mkdir ~/elwood_data && \
+    unzip gadm36_0.feather.zip -d ~/elwood_data/ && \
     unzip gadm36_2.feather.zip -d ~/elwood_data/ && \
     unzip gadm36_3.feather.zip -d ~/elwood_data/ && \
     rm gadm36_?.feather.zip

--- a/tasks/Dockerfile.datamodeling
+++ b/tasks/Dockerfile.datamodeling
@@ -2,18 +2,54 @@ FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y software-properties-common && \
     apt-get update && \
-    apt-get install -y g++ gdal-bin=3.4.1+dfsg-1build4 libgdal-dev=3.4.1+dfsg-1build4 && \
+    apt-get install -y make g++ gdal-bin=3.4.1+dfsg-1build4 libgdal-dev=3.4.1+dfsg-1build4 && \
     apt-get -y install libhdf5-dev libhdf5-serial-dev hdf5-tools && \
-    apt install -y wget unzip python3-rtree python3-all-dev tesseract-ocr ghostscript && \
-    apt install -y python3-pip
+    apt install -y wget unzip python3-rtree python3-all-dev tesseract-ocr ghostscript libffi-dev
+    # apt install -y python3-pip
+
+# Download and install Python 3.8
+RUN wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz && \
+    tar xzf Python-3.8.12.tgz && \
+    cd Python-3.8.12 && \
+    ./configure --enable-optimizations && \
+    make altinstall && \
+    cd .. && \
+    rm -rf Python-3.8.12 Python-3.8.12.tgz
+
+# Make python3.8 the default python
+RUN update-alternatives --install /usr/bin/python python /usr/local/bin/python3.8 1
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1
+
+# Verify Python version
+RUN python --version
+RUN python3 --version
+
+# Install pip for Python 3.8
+RUN wget https://bootstrap.pypa.io/get-pip.py && \
+    python3.8 get-pip.py && \
+    rm get-pip.py && \
+    python3.8 -m pip install --upgrade pip setuptools==57.5.0
+
+# Verify Python and pip version
+RUN python --version
+RUN python3 --version
+RUN python3.8 -m pip --version
+
+# Upgrade pip
+RUN python -m pip install --upgrade pip
+
+# Install cython using pip
+RUN python3.8 -m pip install cython
 
 RUN gdalinfo --version
 
 RUN apt install --no-install-recommends -y libreoffice-writer libreoffice-impress    
 
+RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_0.feather.zip
 RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_2.feather.zip
 RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_3.feather.zip
 RUN mkdir ~/elwood_data && \
+    unzip gadm36_0.feather.zip -d ~/elwood_data/ && \
     unzip gadm36_2.feather.zip -d ~/elwood_data/ && \
     unzip gadm36_3.feather.zip -d ~/elwood_data/ && \
     rm gadm36_?.feather.zip
@@ -25,7 +61,7 @@ ENV GADM_DIR=/root/elwood_data
 RUN pip install --upgrade pip
 RUN pip install numpy==1.22  # Numpy must be installed before GDAL (in requirements.txt) to prevent issues
 
-COPY ./tasks/requirements.txt /tasks/requirements.txt
+COPY ./tasks/requirements.datamodeling.txt /tasks/requirements.txt
 WORKDIR /tasks
 RUN pip install -r requirements.txt
 

--- a/tasks/Dockerfile.datamodeling
+++ b/tasks/Dockerfile.datamodeling
@@ -1,0 +1,34 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y software-properties-common && \
+    apt-get update && \
+    apt-get install -y g++ gdal-bin=3.4.1+dfsg-1build4 libgdal-dev=3.4.1+dfsg-1build4 && \
+    apt-get -y install libhdf5-dev libhdf5-serial-dev hdf5-tools && \
+    apt install -y wget unzip python3-rtree python3-all-dev tesseract-ocr ghostscript && \
+    apt install -y python3-pip
+
+RUN gdalinfo --version
+
+RUN apt install --no-install-recommends -y libreoffice-writer libreoffice-impress    
+
+RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_2.feather.zip
+RUN wget https://jataware-world-modelers.s3.amazonaws.com/gadm/gadm36_3.feather.zip
+RUN mkdir ~/elwood_data && \
+    unzip gadm36_2.feather.zip -d ~/elwood_data/ && \
+    unzip gadm36_3.feather.zip -d ~/elwood_data/ && \
+    rm gadm36_?.feather.zip
+
+ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
+ENV C_INCLUDE_PATH=/usr/include/gdal
+ENV GADM_DIR=/root/elwood_data
+
+RUN pip install --upgrade pip
+RUN pip install numpy==1.22  # Numpy must be installed before GDAL (in requirements.txt) to prevent issues
+
+COPY ./tasks/requirements.txt /tasks/requirements.txt
+WORKDIR /tasks
+RUN pip install -r requirements.txt
+
+COPY ./tasks /tasks
+
+ENV PYTHONPATH "${PYTHONPATH}:/api"

--- a/tasks/Dockerfile.datamodeling
+++ b/tasks/Dockerfile.datamodeling
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y software-properties-common && \
     apt-get update && \
     apt-get install -y make g++ gdal-bin=3.4.1+dfsg-1build4 libgdal-dev=3.4.1+dfsg-1build4 && \
     apt-get -y install libhdf5-dev libhdf5-serial-dev hdf5-tools && \
-    apt install -y wget unzip python3-rtree python3-all-dev tesseract-ocr ghostscript libffi-dev
+    apt install -y wget unzip python3-rtree python3-all-dev tesseract-ocr ghostscript libffi-dev libbz2-dev
     # apt install -y python3-pip
 
 # Download and install Python 3.8

--- a/tasks/docker-compose.yaml
+++ b/tasks/docker-compose.yaml
@@ -26,6 +26,20 @@ services:
       - --url
       - redis://${REDIS_HOST}:${REDIS_PORT}
       - rag   
+  rqworker-datamodeling:
+    build:
+      context: .
+      dockerfile: Dockerfile.datamodeling
+    container_name: dojo-rq-worker-datamodeling
+    networks:
+      - dojo
+    command:
+      - rq
+      - worker
+      - --url
+      - redis://${REDIS_HOST}:${REDIS_PORT}
+      - datamodeling
+      
     # deploy:
     #   resources:
     #     reservations:

--- a/tasks/tasks/data_modeling.py
+++ b/tasks/tasks/data_modeling.py
@@ -20,6 +20,7 @@ from flowcast.regrid import RegridType
 from collections import defaultdict, deque
 from typing import Callable, Literal, TypedDict, Union
 from typing_extensions import Annotated, NotRequired
+from data_modeling_preview_generation import generate_preview
 import traceback
 # from pydantic import BaseModel, Field
 
@@ -515,7 +516,12 @@ def run_partial_flowcast_job(context:PreviewFlowcastContext) -> dict:
         execute_pipeline(pipe, loaders, saved_nodes)
 
         # return the result state of all nodes in the partial graph
-        results = { node['id']: pipe.get_value(node['id']).data for node in partial_graph['nodes'] }
+        results = { }
+        for node in partial_graph['nodes']:
+            id = node['id']
+            data = pipe.get_value(id).data
+            results[id] = generate_preview(data)
+
         return {
             'message': 'successfully ran partial flowcast job',
             'results': results

--- a/tasks/tasks/data_modeling.py
+++ b/tasks/tasks/data_modeling.py
@@ -488,10 +488,11 @@ def validate_flowcast_job(context:FlowcastContext) -> dict:
         traceback_str = traceback.format_exc()
         print(f'Flowcast job validation failed', flush=True)
         print(traceback_str, flush=True)
-        return {
-            'message': 'error validating flowcast job',
-            'error': f'{e}\n{traceback_str}'
-        }
+        # return {
+        #     'message': 'error validating flowcast job',
+        #     'error': f'{e}\n{traceback_str}'
+        # }
+        raise e
 
 
 def run_flowcast_job(context:FlowcastContext) -> dict:

--- a/tasks/tasks/data_modeling.py
+++ b/tasks/tasks/data_modeling.py
@@ -513,11 +513,12 @@ def run_partial_flowcast_job(context:PreviewFlowcastContext) -> dict:
         partial_graph = filter_target_node(context['dag'], node_id)
         pipe, loaders, saved_nodes = create_pipeline({'dag': partial_graph})
         execute_pipeline(pipe, loaders, saved_nodes)
-        # return the value of the target node
-        target_value = pipe.get_value(node_id).data
+
+        # return the result state of all nodes in the partial graph
+        results = { node['id']: pipe.get_value(node['id']).data for node in partial_graph['nodes'] }
         return {
             'message': 'successfully ran partial flowcast job',
-            'target_value': target_value
+            'results': results
         }
     except Exception as e:
         # print exception with stack trace

--- a/tasks/tasks/data_modeling.py
+++ b/tasks/tasks/data_modeling.py
@@ -536,10 +536,7 @@ def run_partial_flowcast_job(context:PreviewFlowcastContext) -> dict:
         traceback_str = traceback.format_exc()
         print(f'Partial flowcast job failed', flush=True)
         print(traceback_str, flush=True)
-        return {
-            'message': 'error running partial flowcast job',
-            'error': f'{e}\n{traceback_str}'
-        }
+        raise e
 
 
 ################################################################################

--- a/tasks/tasks/data_modeling.py
+++ b/tasks/tasks/data_modeling.py
@@ -366,11 +366,12 @@ def run_flowcast_job(context:FlowcastContext) -> dict:
     except Exception as e:
         # print exception with stack trace
         import traceback
-        traceback.print_exc()
+        traceback_str = traceback.format_exc()
         print(f'Flowcast job failed', flush=True)
+        print(traceback_str, flush=True)
         return {
             'message': 'error running flowcast job',
-            'error': str(e)
+            'error': f'{e}\n{traceback_str}'
         }
 
 def unhandled_run_flowcast_job(context:FlowcastContext) -> dict:

--- a/tasks/tasks/data_modeling.py
+++ b/tasks/tasks/data_modeling.py
@@ -529,7 +529,7 @@ def run_partial_flowcast_job(context:PreviewFlowcastContext) -> dict:
 
         return {
             'message': 'successfully ran partial flowcast job',
-            'results': results
+            'previews': results
         }
     except Exception as e:
         # print exception with stack trace

--- a/tasks/tasks/data_modeling_preview_generation.py
+++ b/tasks/tasks/data_modeling_preview_generation.py
@@ -1,0 +1,251 @@
+from typing import Protocol
+import numpy as np
+import xarray as xr
+from matplotlib import pyplot as plt
+import base64
+from io import BytesIO
+from cartopy import crs as ccrs
+from cartopy import feature as cfeature
+import geopandas as gpd
+import pandas as pd
+import matplotlib.cm as cm
+import pycountry
+
+
+def symmetric_log(data: xr.DataArray) -> xr.DataArray:
+    """Apply a symmetric log transform to the data"""
+    return np.sign(data) * np.log(np.abs(data) + 1)
+
+
+def get_px_size() -> float:
+    return 1/plt.rcParams['figure.dpi']  # pixel in inches
+
+
+def generate_preview(data: xr.DataArray, resolution=256, cmap='viridis') -> dict:
+    """Generate a preview of the data for the frontend"""
+    log_data = symmetric_log(data)
+
+    # different cases for data with different dimensions
+    coords_set = set(data.coords)
+    contains_time = 'time' in coords_set
+    coords_set.discard('time')
+
+    if coords_set == {}:
+        fn = generate_time_preview
+    elif coords_set == {'lat', 'lon'}:
+        fn = generate_lat_lon_preview
+    elif coords_set == {'admin0'}:
+        fn = generate_country_preview
+    elif coords_set == {'lat', 'lon', 'admin0'}:
+        fn = generate_country_lat_lon_preview
+
+    # TODO: other cases
+    # elif coords_set == {'lat', 'country'}: ...
+    # elif coords_set == {'lon', 'country'}: ...
+    # elif coords_set == {'lat'}: ...
+    # elif coords_set == {'lon'}: ...
+
+    else:
+        # raise ValueError(f'Unhandled data dimensions: {data.dims}')
+        print(f'Unhandled data dimensions: {data.dims}')
+        fn = generate_random_image
+
+    if len(coords_set) == 0 or not contains_time:
+        previews = [fn(data, resolution, cmap)]
+        log_previews = [fn(log_data, resolution, cmap)]
+    else:
+        previews = generate_sliced_time_preview(fn, data, resolution, cmap)
+        log_previews = generate_sliced_time_preview(fn, log_data, resolution, cmap)
+
+    preview = {
+        'shape': data.shape,
+        'dtype': str(data.dtype),
+        'dims': list(data.dims),
+        'has_NaN': data.isnull().any().item(),
+        'preview': previews,
+        'log_preview': log_previews
+    }
+    return preview
+
+
+class PreviewGenerator(Protocol):
+    def __call__(self, data: xr.DataArray, resolution: int, cmap) -> str: ...
+
+
+def generate_sliced_time_preview(slice_preview_fn: PreviewGenerator, data: xr.DataArray, resolution: int, cmap, max_images=5):
+    """
+    Generate a set of base64 image previews of the given data array sliced along time dimension
+
+    Args:
+        slice_preview_fn: a function that generates a base64 image preview of a single slice of the data
+        data: the data array to generate previews of
+        resolution: the resolution of the preview images
+        cmap: the colormap to use for the preview images
+        max_images: the maximum number of images to generate
+    """
+    indices = np.linspace(0, len(data['time']) - 1, max_images, dtype=int)
+    indices = np.unique(indices)  # remove duplicates
+
+    frames = [
+        slice_preview_fn(data.isel(time=i), resolution, cmap)
+        for i in indices
+    ]
+    return frames
+
+
+def generate_lat_lon_preview(data: xr.DataArray, resolution: int, cmap) -> str:
+    """Generate a base64 image preview of the given data array containing only lat and lon dimensions"""
+    aspect_ratio = data.sizes['lon'] / data.sizes['lat']
+    px = 1/plt.rcParams['figure.dpi']  # pixel in inches
+    figsize = (resolution * aspect_ratio * px, resolution * px)
+
+    # plot and save the regular data
+    fig, ax = plt.subplots(figsize=figsize)
+    ax.axis('off')
+    data.plot(ax=ax, cmap=cmap, add_colorbar=False)
+    ax.set_title('')
+    ax.set_xlabel('')
+    ax.set_ylabel('')
+    ax.set_yticks([])
+    ax.set_xticks([])
+    # plt.show(); pdb.set_trace(); ...; return
+    buf = BytesIO()
+    plt.savefig(buf, format='png', bbox_inches='tight', pad_inches=0)
+    plt.close(fig)
+    preview = base64.b64encode(buf.getvalue()).decode('utf-8')
+
+    return preview
+
+
+def generate_time_preview(data: xr.DataArray, resolution: int, cmap) -> str:
+    """just use the built-in xarray plot method"""
+    fig, ax = plt.subplots(figsize=(resolution, resolution))
+    ax.axis('off')
+    data.plot(ax=ax, cmap=cmap, add_colorbar=False)
+    # plt.show(); pdb.set_trace(); ...; return
+    buf = BytesIO()
+    plt.savefig(buf, format='png', bbox_inches='tight', pad_inches=0)
+    plt.close(fig)
+    preview = base64.b64encode(buf.getvalue()).decode('utf-8')
+    return preview
+
+
+def gadm_admin0_to_iso3(admin0: str) -> str:
+    """Convert a GADM admin0 name to an ISO 3166-1 alpha-3 country code"""
+    try:
+        return pycountry.countries.lookup(admin0).alpha_3
+    except:
+        raise ValueError(f'Could not find ISO 3166-1 alpha-3 code for {admin0}') from None
+
+
+def try_or_none(fn, *args, message: str = None, **kwargs):
+    try:
+        return fn(*args, **kwargs)
+    except Exception as e:
+        print(f'Error: {e}. {message or ""}')
+        return None
+
+
+def generate_country_preview(data: xr.DataArray, resolution: int, cmap) -> str:
+    iso3_names = [try_or_none(gadm_admin0_to_iso3, name, message='skipping for preview')
+                  for name in data['admin0'].values]
+    assert len(data.values) == len(iso3_names), f'{len(data.values)=} != {len(iso3_names)=}'
+    country_data = dict(filter(lambda x: x[0] is not None, zip(iso3_names, data.values)))
+
+    # Create a figure with a Mollweide projection
+    px = get_px_size()
+    fig = plt.figure(figsize=(2*resolution*px, resolution*px))
+    ax = plt.axes(projection=ccrs.Mollweide(central_longitude=1))
+
+    # Set global extent and add coastlines
+    ax.set_global()
+    ax.coastlines()
+
+    # Add country borders
+    ax.add_feature(cfeature.BORDERS, linestyle=':', alpha=0.7)
+
+    # Load Natural Earth shapefile of countries and filter so it only contains the countries we have data for
+    shapefile = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
+    shapefile = shapefile[shapefile['iso_a3'].isin(country_data.keys())]
+
+    # Add data to the shapefile
+    shapefile['data_value'] = shapefile['iso_a3'].map(country_data)
+
+    # Plot each country with a color depending on its value in the data
+    for _, country in shapefile.iterrows():
+        if not pd.isnull(country['data_value']):
+            ax.add_geometries(
+                [country['geometry']],
+                crs=ccrs.PlateCarree(),
+                facecolor=cm.viridis(country['data_value'] / max(country_data.values())),
+                edgecolor='black'
+            )
+    # plt.show(); pdb.set_trace(); ...; return
+    buf = BytesIO()
+    plt.savefig(buf, format='png', bbox_inches='tight', pad_inches=0)
+    plt.close(fig)
+    preview = base64.b64encode(buf.getvalue()).decode('utf-8')
+    return preview
+
+
+def generate_country_lat_lon_preview(data: xr.DataArray, resolution: int, cmap) -> str:
+    px = get_px_size()
+    fig = plt.figure(figsize=(2*resolution*px, resolution*px))
+    ax = plt.axes(projection=ccrs.Mollweide(central_longitude=1))
+
+    # Set global extent and add coastlines
+    ax.set_global()
+    ax.coastlines()
+
+    # get lat/lon/data as numpy arrays
+    lat = data['lat'].data
+    lon = data['lon'].data
+    # sum data along admin0 dimension to get rid of the extra dimension
+    data = data.sum(dim='admin0', skipna=True, min_count=1).values
+
+    # Plot gridded data using pcolormesh, transformed to the map's projection
+    mesh = ax.pcolormesh(lon, lat, data, transform=ccrs.PlateCarree(), cmap=cmap, shading='auto')
+
+    # Add country borders
+    ax.add_feature(cfeature.BORDERS, linestyle=':', edgecolor='black')
+
+    # Optionally, if you have a geopandas DataFrame of countries, plot it:
+    shapefile = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
+
+    # Ensure countries are plotted in the correct projection
+    for _, country in shapefile.iterrows():
+        ax.add_geometries(
+            [country['geometry']], crs=ccrs.PlateCarree(),
+            facecolor='none', edgecolor='black', lw=0.8
+        )
+
+    # Show the plot
+    # plt.show(); pdb.set_trace(); ...; return
+    buf = BytesIO()
+    plt.savefig(buf, format='png', bbox_inches='tight', pad_inches=0)
+    plt.close(fig)
+    preview = base64.b64encode(buf.getvalue()).decode('utf-8')
+    return preview
+
+
+def generate_random_image(data, resolution: int, cmap) -> str:
+    px = 1/plt.rcParams['figure.dpi']  # pixel in inches
+    fig, ax = plt.subplots(figsize=(resolution*px, resolution*px))
+    ax.axis('off')
+    ax.imshow(np.random.random((resolution, resolution)), cmap=cmap)
+    # plt.show(); pdb.set_trace(); ...; return
+    buf = BytesIO()
+    plt.savefig(buf, format='png', bbox_inches='tight', pad_inches=0)
+    plt.close(fig)
+    randimg = base64.b64encode(buf.getvalue()).decode('utf-8')
+    return randimg
+
+
+def plot_png64(img: str):
+    """Plot a base64 encoded image"""
+    img = base64.b64decode(img)
+    img = BytesIO(img)
+    img = plt.imread(img)
+    plt.imshow(img)
+    plt.axis('off')
+    plt.show()

--- a/tasks/tasks/data_modeling_preview_generation.py
+++ b/tasks/tasks/data_modeling_preview_generation.py
@@ -20,9 +20,11 @@ def symmetric_log(data: xr.DataArray) -> xr.DataArray:
 def get_px_size() -> float:
     return 1/plt.rcParams['figure.dpi']  # pixel in inches
 
+class ProjType:
+    mollweide = ccrs.Mollweide(central_longitude=1) # there's a bug when central_longitude is smaller than 1
+    robinson = ccrs.Robinson()
 
-
-def generate_preview(data: xr.DataArray, resolution=256, cmap='viridis', projection:ccrs.Projection=ccrs.Robinson()) -> dict:
+def generate_preview(data: xr.DataArray, resolution=256, cmap='viridis', projection:ccrs.Projection=ProjType.robinson) -> dict:
     """Generate a preview of the data for the frontend"""
     log_data = symmetric_log(data)
 

--- a/tasks/tasks/data_modeling_preview_generation.py
+++ b/tasks/tasks/data_modeling_preview_generation.py
@@ -112,20 +112,28 @@ def generate_preview(data: xr.DataArray, resolution=512, cmap='viridis', project
     fn: SlicedDualPreviewGenerator
     if len(coords_set) == 0:
         fn = make_sliced_dual(generate_time_preview)
+        print('Generating time preview')
     elif coords_set == {'lat'}:
         fn = make_sliced_dual(generate_lat_preview)
+        print('Generating lat preview')
     elif coords_set == {'lon'}:
         fn = make_sliced_dual(generate_lon_preview)
+        print('Generating lon preview')
     elif coords_set == {'admin0'}:
         fn = make_sliced_dual(generate_country_preview)
+        print('Generating country preview')
     elif coords_set == {'lat', 'lon'}:
         fn = make_sliced_dual(generate_lat_lon_preview)
+        print('Generating lat/lon preview')
     elif coords_set == {'lat', 'admin0'}:
         fn = generate_lat_country_preview
+        print('Generating lat/country preview')
     elif coords_set == {'lon', 'admin0'}:
         fn = generate_lon_country_preview
+        print('Generating lon/country preview')
     elif coords_set == {'lat', 'lon', 'admin0'}:
         fn = make_sliced_dual(generate_country_lat_lon_preview)
+        print('Generating lat/lon/country preview')
 
     else:
         # raise ValueError(f'Unhandled data dimensions: {data.dims}')
@@ -158,7 +166,7 @@ def generate_time_preview(data: xr.DataArray, resolution: int, cmap: str, projec
 
     # regular plot
     fig, ax = plt.subplots(figsize=(resolution*px, resolution*px))
-    ax.axis('off')
+    # ax.axis('off')
     data.plot(ax=ax)
     preview = save_fig_to_base64()
 
@@ -269,6 +277,12 @@ def generate_country_lat_lon_preview(data: xr.DataArray, resolution: int, cmap, 
     lons = data['lon'].data
     # sum data along admin0 dimension to get rid of the extra dimension
     data = data.sum(dim='admin0', skipna=True, min_count=1).values
+
+    # Mask NaN and zero values
+    # TODO: figure out how best to handle NaN and zero values in the data after multiplication (since it will be a binary mask)
+    # masked_data = np.ma.masked_where((data == 0) | np.isnan(data), data)
+    # print(f'Number of NaN values: {np.sum(np.isnan(data))}')
+    # print(f'Number of zero values: {np.sum(data == 0)}')
 
     # determine the lat/lon extents of the data
     lat_bounds, lon_bounds, projection, aspect = get_best_view(lats, lons, projection)

--- a/tasks/tasks/data_modeling_preview_generation.py
+++ b/tasks/tasks/data_modeling_preview_generation.py
@@ -246,17 +246,7 @@ def generate_country_lat_lon_preview(data: xr.DataArray, resolution: int, cmap, 
     mesh = ax.pcolormesh(lon, lat, data, transform=ccrs.PlateCarree(), cmap=cmap, shading='auto')
 
     # Add country borders
-    ax.add_feature(cfeature.BORDERS, linestyle=':', edgecolor='black')
-
-    # Optionally, if you have a geopandas DataFrame of countries, plot it:
-    shapefile = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))
-
-    # Ensure countries are plotted in the correct projection
-    for _, country in shapefile.iterrows():
-        ax.add_geometries(
-            [country['geometry']], crs=ccrs.PlateCarree(),
-            facecolor='none', edgecolor='black', lw=0.8
-        )
+    ax.add_feature(cfeature.BORDERS, edgecolor='black', lw=0.8)
 
     # save and return the preview
     preview = save_fig_to_base64()

--- a/tasks/tasks/data_modeling_preview_generation.py
+++ b/tasks/tasks/data_modeling_preview_generation.py
@@ -121,7 +121,7 @@ def generate_preview(data: xr.DataArray, resolution=512, cmap='viridis', project
     else:
         # raise ValueError(f'Unhandled data dimensions: {data.dims}')
         print(f'Unhandled data dimensions: {data.dims}, coords_set={coords_set}')
-        fn = make_sliced_dual(generate_random_image)
+        fn = make_sliced_dual(generate_missing_image)
 
     # generate the previews and log previews
     previews, log_previews = fn(data, resolution, cmap, projection)
@@ -319,16 +319,15 @@ def execute_pipeline_op(data: xr.DataArray, op: Callable[[Pipeline], None]) -> x
     return data
 
 
-def generate_random_image(data, resolution: int, cmap: str, projection: ccrs.Projection) -> png64:
+def generate_missing_image(data, resolution: int, cmap: str, projection: ccrs.Projection) -> png64:
     px = 1/plt.rcParams['figure.dpi']  # pixel in inches
     fig, ax = plt.subplots(figsize=(resolution*px, resolution*px))
     ax.axis('off')
     ax.imshow(np.random.random((resolution, resolution)), cmap=cmap)
-    buf = BytesIO()
-    plt.savefig(buf, format='png', bbox_inches='tight', pad_inches=0)
-    plt.close(fig)
-    randimg = base64.b64encode(buf.getvalue()).decode('utf-8')
-    return randimg
+    ax.text(resolution/2, resolution/2, 'NO PREVIEW\nAVAILABLE', color='white', fontsize=36, ha='center', va='center')
+
+    img = save_fig_to_base64()
+    return img
 
 
 def plot_png64(img: png64):

--- a/tasks/tasks/requirements.datamodeling.txt
+++ b/tasks/tasks/requirements.datamodeling.txt
@@ -1,0 +1,24 @@
+boto3==1.24.8
+elasticsearch==7.12.0
+cartopy==0.21.1
+cartwright==0.0.3
+h5netcdf==1.0.1
+numpy==1.22
+netCDF4==1.5.3
+matplotlib==3.5.2
+setuptools==57.5.0
+GDAL==3.4.1
+elwood==0.1.4
+pandas==1.5.3
+python-dateutil==2.8.2
+raster2xyz==0.1.3
+requests==2.28.1
+rq==1.11.0
+scipy==1.9.3
+# torchvision==0.16.1  # Imported in unused anomaly detection
+tqdm==4.64.0
+xarray==0.19.0
+h5py
+rasterio
+urllib3<2
+flowcast>=0.5.1

--- a/tasks/tasks/requirements.datamodeling.txt
+++ b/tasks/tasks/requirements.datamodeling.txt
@@ -14,10 +14,10 @@ python-dateutil==2.8.2
 raster2xyz==0.1.3
 requests==2.28.1
 rq==1.11.0
-scipy==1.9.3
+scipy==1.10.1
 tqdm==4.64.0
 xarray==0.19.0
 # h5py==2.10.0
 rasterio<1.3
 urllib3<2
-flowcast>=0.5.1
+flowcast>=0.5.2

--- a/tasks/tasks/requirements.datamodeling.txt
+++ b/tasks/tasks/requirements.datamodeling.txt
@@ -7,7 +7,7 @@ numpy==1.22
 netCDF4==1.5.3
 matplotlib==3.5.2
 setuptools==57.5.0
-GDAL==3.4.1
+GDAL==3.2.2
 elwood==0.1.4
 pandas==1.5.3
 python-dateutil==2.8.2
@@ -15,10 +15,9 @@ raster2xyz==0.1.3
 requests==2.28.1
 rq==1.11.0
 scipy==1.9.3
-# torchvision==0.16.1  # Imported in unused anomaly detection
 tqdm==4.64.0
 xarray==0.19.0
-h5py
-rasterio
+# h5py==2.10.0
+rasterio<1.3
 urllib3<2
 flowcast>=0.5.1

--- a/tasks/tasks/requirements.txt
+++ b/tasks/tasks/requirements.txt
@@ -1,5 +1,7 @@
 boto3==1.24.8
 elasticsearch==7.12.0
+cartopy==0.21.1
+pycountry==24.6.1
 cartwright==0.0.3
 h5netcdf==1.0.1
 numpy==1.22

--- a/tasks/tasks/requirements.txt
+++ b/tasks/tasks/requirements.txt
@@ -5,6 +5,7 @@ h5netcdf==1.0.1
 numpy==1.22
 netCDF4==1.5.3
 matplotlib==3.5.2
+setuptools==57.5.0
 GDAL==3.2.2
 elwood==0.1.4
 pandas==1.5.3
@@ -12,11 +13,11 @@ python-dateutil==2.8.2
 raster2xyz==0.1.3
 requests==2.28.1
 rq==1.11.0
-scipy==1.6.2
+scipy==1.9.3
 # torchvision==0.16.1  # Imported in unused anomaly detection
 tqdm==4.64.0
 xarray==0.19.0
 h5py==2.10.0
 rasterio<1.3
 urllib3<2
-flowcast>=0.3.5
+flowcast>=0.3.8

--- a/tasks/tasks/requirements.txt
+++ b/tasks/tasks/requirements.txt
@@ -1,7 +1,6 @@
 boto3==1.24.8
 elasticsearch==7.12.0
 cartopy==0.21.1
-pycountry==24.6.1
 cartwright==0.0.3
 h5netcdf==1.0.1
 numpy==1.22
@@ -22,4 +21,4 @@ xarray==0.19.0
 h5py==2.10.0
 rasterio<1.3
 urllib3<2
-flowcast>=0.4.0
+flowcast>=0.5.0

--- a/tasks/tasks/requirements.txt
+++ b/tasks/tasks/requirements.txt
@@ -22,4 +22,4 @@ xarray==0.19.0
 h5py==2.10.0
 rasterio<1.3
 urllib3<2
-flowcast>=0.3.8
+flowcast>=0.4.0

--- a/tasks/tasks/requirements.txt
+++ b/tasks/tasks/requirements.txt
@@ -21,4 +21,4 @@ xarray==0.19.0
 h5py==2.10.0
 rasterio<1.3
 urllib3<2
-flowcast>=0.5.0
+flowcast>=0.5.1

--- a/ui/client/dagpipes/DagpipesApp.js
+++ b/ui/client/dagpipes/DagpipesApp.js
@@ -1,18 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import 'reactflow/dist/style.css';
-
-import { Provider, useSelector } from 'react-redux';
-
+import { Provider, useDispatch, useSelector } from 'react-redux';
 import { store } from './store';
 import DagDatasetSelector from './DagDatasetSelector';
 import PipeEditor from './PipeEditor';
 import ModelerProcessing from './ModelerProcessing';
 import ModelerSummary from './ModelerSummary';
+import { setModelerStep } from './dagSlice'; // Import actions from your Redux slice
 
 const DagSteps = () => {
   const { modelerStep } = useSelector((state) => state.dag);
-  // TODO: change this to be in redux so we don't lose state every time there's a code change
-  // const [step, setStep] = useState('select');
 
   switch (modelerStep) {
     case 0:
@@ -24,12 +21,22 @@ const DagSteps = () => {
     case 3:
       return <ModelerSummary />;
     default:
-      // TODO: error page?
       console.log('There was an error');
   }
 };
 
 function App() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const savedFlowValue = localStorage.getItem('dagpipes-flow-session');
+    if (savedFlowValue) {
+      // Update Redux state to skip to the editor step and load the DAG
+      // dispatch(setFlowValue(JSON.parse(savedFlowValue)));
+      dispatch(setModelerStep(1)); // Assuming 1 is the step for PipeEditor
+    }
+  }, [dispatch]);
+
   return (
     <Provider store={store}>
       <DagSteps />

--- a/ui/client/dagpipes/PipeEditor.js
+++ b/ui/client/dagpipes/PipeEditor.js
@@ -161,20 +161,41 @@ const useStyles = makeStyles()((theme) => ({
     minHeight: '400px',
     minWidth: '400px',
   },
-  opaqueButton: {
-    backgroundColor: 'white',
-    color: 'black',
-    '&:hover': {
-      backgroundColor: theme.palette.grey[100],
+    opaqueButton: {
+      backgroundColor: 'white',
+      color: 'black',
+      '&:hover': {
+        backgroundColor: theme.palette.grey[100],
+      },
     },
-  },
-  lowerSidebar: {
-    margin: `${theme.spacing(4)} ${theme.spacing(2)} ${theme.spacing(2)}`,
-  },
-  wholeSidebar: {
-    width: '275px',
-    minWidth: '275px',
-  },
+    lowerSidebar: {
+      margin: `${theme.spacing(4)} ${theme.spacing(2)} ${theme.spacing(2)}`,
+    },
+    wholeSidebar: {
+      width: '275px',
+      minWidth: '275px',
+    },
+    validateButton: {
+      backgroundColor: 'grey',
+      color: 'white',
+      '&:hover': {
+        backgroundColor: 'grey',
+      },
+    },
+    validateButtonSuccess: {
+      backgroundColor: 'green',
+      color: 'white',
+      '&:hover': {
+        backgroundColor: 'green',
+      },
+    },
+    validateButtonError: {
+      backgroundColor: 'red',
+      color: 'white',
+      '&:hover': {
+        backgroundColor: 'red',
+      },
+    },
 }));
 
 const PipeEditor = () => {
@@ -397,9 +418,9 @@ const PipeEditor = () => {
       console.log("Validating data model");
       const flowValue = onSave();
       const UUID = crypto.randomUUID();
-      setValidationLoading(true);
+      setValidationLoading(true); // Set loading state to true
       setValidationSuccess(false);
-      setValidationError(false);      
+      setValidationError(false);
       const response = await axios.post(
         `/api/dojo/job/${UUID}/data_modeling.validate_flowcast_job`,
         { context: { dag: flowValue } },
@@ -412,24 +433,24 @@ const PipeEditor = () => {
         const jobStatus = statusResponse.data.status;
         if (jobStatus === 'finished') {
           clearInterval(intervalId);
-          setValidationLoading(false); 
+          setValidationLoading(false); // Set loading state to false
           setValidationSuccess(true);
-          setTimeout(() => setValidationSuccess(false), 5000);
+          setTimeout(() => setValidationSuccess(false), 10000); // Remove success icon after 10 seconds
           console.log('Job finished successfully', statusResponse.data.result.message);
         } else if (jobStatus === 'failed') {
           clearInterval(intervalId);
-          setValidationLoading(false); 
+          setValidationLoading(false); // Set loading state to false
           setValidationError(true);
           setErrorMessage(statusResponse.data.job_error);
-          setTimeout(() => setValidationError(false), 7000);
+          setTimeout(() => setValidationError(false), 10000); // Remove error icon after 10 seconds
           console.error('Job failed', statusResponse.data.job_error);
         }
       }, 2000); // Poll every 2 seconds
     } catch (error) {
-      setValidationLoading(false);
+      setValidationLoading(false); // Set loading state to false
       setValidationError(true);
       setErrorMessage(error.message);
-      setTimeout(() => setValidationError(false), 7000); // Remove error icon after 5 seconds
+      setTimeout(() => setValidationError(false), 10000); // Remove error icon after 10 seconds
       console.error('Error triggering validation job:', error);
     }
   };
@@ -549,7 +570,15 @@ const PipeEditor = () => {
             variant="contained"
             disableElevation
             fullWidth
-            color="secondary"
+            className={
+              validationLoading
+                ? classes.validateButton
+                : validationSuccess
+                ? classes.validateButtonSuccess
+                : validationError
+                ? classes.validateButtonError
+                : classes.validateButton
+            }
             sx={{ marginTop: 2 }}
             onClick={handleValidateClick}
             disabled={validationLoading}
@@ -559,11 +588,11 @@ const PipeEditor = () => {
             ) : validationSuccess ? (
               <CheckCircleIcon style={{ color: 'white' }} />
             ) : validationError ? (
-              <ErrorIcon style={{ color: 'red' }} />
+              <ErrorIcon style={{ color: 'white' }} />
             ) : (
               'Validate Data Model'
             )}
-          </Button>       
+          </Button>     
           <Tooltip title={processDisabled ? disabledProcessTooltip : ''}>
             <span>
               <Button

--- a/ui/client/dagpipes/PipeEditor.js
+++ b/ui/client/dagpipes/PipeEditor.js
@@ -231,6 +231,7 @@ const PipeEditor = () => {
   const [previewsLoading, setPreviewsLoading] = useState(false);
   const [previewsSuccess, setPreviewsSuccess] = useState(false);
   const [previewsError, setPreviewsError] = useState(false);
+  const [previews, setPreviews] = useState({});
 
   const {
     geoResolutionColumn, timeResolutionColumn
@@ -503,6 +504,26 @@ const PipeEditor = () => {
           setPreviewsSuccess(true);
           setTimeout(() => setPreviewsSuccess(false), 10000); // Remove success icon after 10 seconds
           console.log('Job finished successfully', statusResponse.data.result.message);
+          console.log('Job finished. Preview images:', statusResponse.data.result.previews);
+          const previewData = statusResponse.data.result.previews;
+          setPreviews(previewData);  
+
+          setNodes((nds) =>
+            nds.map((node) => {
+              const nodePreviews = previewData[node.id]?.preview || [];
+              const nodeLogPreviews = previewData[node.id]?.log_preview || [];
+          
+              return {
+                ...node,
+                data: {
+                  ...node.data,
+                  previews: nodePreviews,
+                  logPreviews: nodeLogPreviews,
+                },
+              };
+            })
+          );
+  
         } else if (jobStatus === 'failed') {
           clearInterval(intervalId);
           setPreviewsLoading(false); // Set loading state to false
@@ -566,6 +587,13 @@ const PipeEditor = () => {
 
   const handleStatsClick = () => {
     setShowStats((prev) => !prev);
+  };
+
+  const renderNodePreviews = (nodeId) => {
+    const nodePreviews = previews[nodeId]?.preview || [];
+    return nodePreviews.map((img, index) => (
+      <img key={index} src={`data:image/png;base64,${img}`} alt={`Preview ${index}`} />
+    ));
   };
 
   return (

--- a/ui/client/dagpipes/PipeEditor.js
+++ b/ui/client/dagpipes/PipeEditor.js
@@ -488,6 +488,26 @@ const PipeEditor = () => {
       setPreviewsLoading(true); // Set loading state to true
       setPreviewsSuccess(false);
       setPreviewsError(false);
+
+      // Check local storage usage and clear old data if necessary
+      const checkAndClearStorage = () => {
+        const allKeys = Object.keys(localStorage);
+        const storageLimit = 5 * 1024 * 1024; // 5MB limit for local storage
+        let totalSize = 0;
+
+        allKeys.forEach(key => {
+          totalSize += localStorage.getItem(key).length;
+        });
+
+        if (totalSize >= storageLimit) {
+          console.warn('Local storage limit reached. Clearing old data...');
+          localStorage.clear();
+        }
+      };
+
+      checkAndClearStorage();      
+
+      // handle response
       const response = await axios.post(
         `/api/dojo/job/${UUID}/data_modeling.run_partial_flowcast_job`,
         { context: { dag: flowValue , node_id: null }},

--- a/ui/client/dagpipes/dagSlice.js
+++ b/ui/client/dagpipes/dagSlice.js
@@ -99,6 +99,25 @@ export const dagSlice = createSlice({
       const { datasetId, metadata } = action.payload;
       state.fetchedMetadata[datasetId] = metadata;
     },
+    setNodesAndEdges: (state, action) => {
+      const { nodes, edges } = action.payload;
+
+      // Ensure nodes are properly set in the state with their full data, including input
+      state.nodes = nodes.map((node) => ({
+        ...node, // Copy all node properties
+        data: {
+          ...node.data, // Preserve existing node data
+          input: node.data?.input || {}, // Ensure the input data is retained
+        },
+      }));
+
+      state.edges = edges;
+      state.nodeCount = nodes.length;
+      state.edgeCount = edges.length;
+    }, 
+    setModelerStep: (state, action) => {
+      state.modelerStep = action.payload;
+    },
   },
 });
 
@@ -124,6 +143,8 @@ export const {
   setFlowcastJobId,
   setCompletedDatasetIds,
   setFetchedMetadata,
+  setNodesAndEdges,
+  setModelerStep,
 } = dagSlice.actions;
 
 export default dagSlice.reducer;

--- a/ui/client/dagpipes/dagSlice.js
+++ b/ui/client/dagpipes/dagSlice.js
@@ -72,7 +72,10 @@ export const dagSlice = createSlice({
       state.unsavedChanges = false;
     },
     setSavedDatasets: (state, action) => {
-      state.savedDatasets = action.payload;
+      if (action.payload && Object.keys(action.payload).length > 0) {
+        state.savedDatasets = action.payload;
+      }
+      // Don't set to empty if payload is empty
     },
     setGeoResolutionColumn: (state, action) => {
       state.geoResolutionColumn = action.payload;

--- a/ui/client/dagpipes/nodes/FilterByCountryNode.js
+++ b/ui/client/dagpipes/nodes/FilterByCountryNode.js
@@ -75,7 +75,7 @@ function Select({
 
 // reduce by country => from re-gridded to country data
 const CustomNode = ({ id, data }) => (
-  <NodeBase title={NodeTitles.FILTER_BY_COUNTRY}>
+  <NodeBase title={NodeTitles.FILTER_BY_COUNTRY} previews={data.previews} logPreviews={data.logPreviews}>
     <Select
       nodeId={id}
       input={data.input}

--- a/ui/client/dagpipes/nodes/LoadNode.js
+++ b/ui/client/dagpipes/nodes/LoadNode.js
@@ -164,7 +164,7 @@ function SelectFeature({ input, nodeId, onChange }) {
 }
 
 const CustomNode = ({ id, data }) => (
-  <NodeBase title={NodeTitles.LOAD}>
+  <NodeBase title={NodeTitles.LOAD} previews={data.previews} logPreviews={data.logPreviews}>
     <SelectFeature
       nodeId={id}
       onChange={data.onChange}

--- a/ui/client/dagpipes/nodes/LoadNode.js
+++ b/ui/client/dagpipes/nodes/LoadNode.js
@@ -40,10 +40,7 @@ function SelectFeature({ input, nodeId, onChange }) {
 
   const [geoSelected, setGeoSelected] = useState(input.data_source === geoResolutionColumn);
   const [timeSelected, setTimeSelected] = useState(input.data_source === timeResolutionColumn);  
-  console.log('Initial data source:', input.data_source);
   const [savedSelectValue, setSavedSelectValue] = useState(input.data_source || '');
-  console.log('Saved datasets:', savedDatasets);
-
 
   const handleGeoChange = (event) => {
     const isChecked = event.target.checked;

--- a/ui/client/dagpipes/nodes/LoadNode.js
+++ b/ui/client/dagpipes/nodes/LoadNode.js
@@ -38,29 +38,30 @@ function SelectFeature({ input, nodeId, onChange }) {
   } = useSelector((state) => state.dag);
   const dispatch = useDispatch();
 
-  const [geoSelected, setGeoSelected] = useState(false);
-  const [timeSelected, setTimeSelected] = useState(false);
-  const [savedSelectValue, setSavedSelectValue] = useState(null);
+  const [geoSelected, setGeoSelected] = useState(input.data_source === geoResolutionColumn);
+  const [timeSelected, setTimeSelected] = useState(input.data_source === timeResolutionColumn);  
+  console.log('Initial data source:', input.data_source);
+  const [savedSelectValue, setSavedSelectValue] = useState(input.data_source || '');
+  console.log('Saved datasets:', savedDatasets);
+
 
   const handleGeoChange = (event) => {
-    setGeoSelected(event.target.checked);
-    let columnUpdate = null;
-    // only dispatch the saved value if it's checked
-    if (event.target.checked) {
-      columnUpdate = savedSelectValue;
-    }
-    // otherwise clear the value with null
+    const isChecked = event.target.checked;
+    setGeoSelected(isChecked);
+    
+    const columnUpdate = isChecked ? savedSelectValue : null;
+    
+    // Dispatch the value to the Redux store
     dispatch(setGeoResolutionColumn(columnUpdate));
   };
 
   const handleTimeChange = (event) => {
-    setTimeSelected(event.target.checked);
-    let columnUpdate = null;
-    // only dispatch the saved value if it's checked
-    if (event.target.checked) {
-      columnUpdate = savedSelectValue;
-    }
-    // otherwise clear the value with null
+    const isChecked = event.target.checked;
+    setTimeSelected(isChecked);
+    
+    const columnUpdate = isChecked ? savedSelectValue : null;
+    
+    // Dispatch the value to the Redux store
     dispatch(setTimeResolutionColumn(columnUpdate));
   };
 
@@ -90,7 +91,7 @@ function SelectFeature({ input, nodeId, onChange }) {
   return (
     <div>
       <ModelerSelect
-        value={input.data}
+        value={savedSelectValue}
         label="Data Source"
         onChange={handleSelectChange}
         name="data_source"
@@ -107,7 +108,7 @@ function SelectFeature({ input, nodeId, onChange }) {
                   {feature}
                 </option>
               );
-            })};
+            })}
           </optgroup>
         ))}
       </ModelerSelect>

--- a/ui/client/dagpipes/nodes/MaskToDistanceFieldNode.js
+++ b/ui/client/dagpipes/nodes/MaskToDistanceFieldNode.js
@@ -12,7 +12,7 @@ import { topHandle, bottomHandle, NodeTitles } from '../constants';
 function CustomNode({ id, data }) {
   return (
     <div>
-      <NodeBase title={NodeTitles.MASK_TO_DISTANCE_FIELD} />
+      <NodeBase title={NodeTitles.MASK_TO_DISTANCE_FIELD} previews={data.previews} logPreviews={data.logPreviews} />
       <Handle
         type="target"
         position={Position.Top}

--- a/ui/client/dagpipes/nodes/MultiplyNode.js
+++ b/ui/client/dagpipes/nodes/MultiplyNode.js
@@ -13,7 +13,7 @@ function CustomNode({ id, data }) {
   const rightHandle = { left: '128px', ...topHandle };
   return (
     <div>
-      <NodeBase title={NodeTitles.MULTIPLY} />
+      <NodeBase title={NodeTitles.MULTIPLY} previews={data.previews} logPreviews={data.logPreviews}/>
       <div className="custom-node__multiply">
         <Handle
           type="target"

--- a/ui/client/dagpipes/nodes/NodeBase.js
+++ b/ui/client/dagpipes/nodes/NodeBase.js
@@ -1,16 +1,108 @@
-import React from 'react';
-
+import React, { useState, useEffect } from 'react';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-
+import Switch from '@mui/material/Switch';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import InlineDocLink from '../../components/uiComponents/InlineDocLink';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 
 const NodeBase = ({
-  children, title, style
+  children, title, style, previews = [], logPreviews = []
 }) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [showLog, setShowLog] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [showOverlay, setShowOverlay] = useState(false);
+
   // parse the title with dashes for the link to the docs
   const dashedTitle = title.toLowerCase().split(' ').join('-');
   const parsedLink = `data-modeling.html#${dashedTitle}-node`;
+
+  useEffect(() => {
+    if (paused) return; // Exit early if paused
+
+    const images = showLog ? logPreviews : previews;
+    if (images.length > 0) {
+      const interval = setInterval(() => {
+        setCurrentIndex((prevIndex) => (prevIndex + 1) % images.length);
+      }, 2000); // Change image every 2 seconds
+
+      return () => clearInterval(interval);
+    }
+  }, [previews, logPreviews, showLog, paused]);
+
+  const handleImageClick = () => {
+    setPaused(!paused);
+    setShowOverlay(true);
+    setTimeout(() => setShowOverlay(false), 500); // Show overlay for 500ms
+  };
+
+  const renderPreviews = () => {
+    const images = showLog ? logPreviews : previews;
+    return (
+      <div style={{ marginTop: '8px', padding: '8px' }}>
+        {images.length > 0 && (
+          <>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
+              <Typography variant="caption" sx={{ fontSize: '0.875rem' }}>
+                Preview:
+              </Typography>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={showLog}
+                    onChange={() => setShowLog(!showLog)}
+                    color="primary"
+                    size="small"
+                  />
+                }
+                label={<Typography variant="caption" sx={{ fontSize: '0.875rem' }}>Log</Typography>}
+                labelPlacement="start"
+                sx={{ margin: 0 }}
+              />
+            </div>
+            <div
+              style={{
+                position: 'relative',
+                backgroundColor: 'white',
+                border: '1px solid lightgrey',
+                borderRadius: '4px',
+                padding: '8px',
+                boxSizing: 'border-box',
+                cursor: 'pointer'
+              }}
+              onClick={handleImageClick}
+            >
+              <img
+                src={`data:image/png;base64,${images[currentIndex]}`}
+                alt={`Preview ${currentIndex}`}
+                style={{
+                  width: '100%',
+                  borderRadius: '4px'
+                }}
+              />
+              {showOverlay && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                    backgroundColor: 'rgba(255, 255, 255, 0.8)',
+                    borderRadius: '50%',
+                    padding: '10px'
+                  }}
+                >
+                  {paused ? <PauseIcon fontSize="large" /> : <PlayArrowIcon fontSize="large" />}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    );
+  };
 
   return (
     <div style={style}>
@@ -26,6 +118,7 @@ const NodeBase = ({
           </div>
         </>
       )}
+      {(previews.length > 0 || logPreviews.length > 0) && renderPreviews()}
     </div>
   );
 };

--- a/ui/client/dagpipes/nodes/SaveNode.js
+++ b/ui/client/dagpipes/nodes/SaveNode.js
@@ -52,7 +52,7 @@ function FileSelect({
 
 function CustomNode({ id, data }) {
   return (
-    <NodeBase title={NodeTitles.SAVE}>
+    <NodeBase title={NodeTitles.SAVE} previews={data.previews} logPreviews={data.logPreviews}>
       <FileSelect
         nodeId={id}
         input={data.input}

--- a/ui/client/dagpipes/nodes/ScalarOperationNode.js
+++ b/ui/client/dagpipes/nodes/ScalarOperationNode.js
@@ -42,7 +42,7 @@ function CustomNode({ id, data, handleId }) {
 
   return (
     <div>
-      <NodeBase title={NodeTitles.SCALAR_OPERATION} />
+      <NodeBase title={NodeTitles.SCALAR_OPERATION} previews={data.previews} logPreviews={data.logPreviews}/>
       <Handle
         type="target"
         position={Position.Top}

--- a/ui/client/dagpipes/nodes/SelectSliceNode.js
+++ b/ui/client/dagpipes/nodes/SelectSliceNode.js
@@ -108,7 +108,7 @@ function CustomNode({ id, data, handleId }) {
 
   return (
     <div>
-      <NodeBase title={NodeTitles.SELECT_SLICE} />
+      <NodeBase title={NodeTitles.SELECT_SLICE} previews={data.previews} logPreviews={data.logPreviews}/>
       <Handle
         type="target"
         position={Position.Top}

--- a/ui/client/dagpipes/nodes/SumNode.js
+++ b/ui/client/dagpipes/nodes/SumNode.js
@@ -85,7 +85,7 @@ function DimensionCheckboxes({
 }
 
 const CustomNode = ({ id, data }) => (
-  <NodeBase title={NodeTitles.REDUCE_BY}>
+  <NodeBase title={NodeTitles.REDUCE_BY} previews={data.previews} logPreviews={data.logPreviews}>
     <DimensionCheckboxes
       nodeId={id}
       onChange={data.onChange}

--- a/ui/client/dagpipes/nodes/ThresholdNode.js
+++ b/ui/client/dagpipes/nodes/ThresholdNode.js
@@ -71,7 +71,7 @@ function Select({
 }
 
 const CustomNode = ({ id, data }) => (
-  <NodeBase title={NodeTitles.THRESHOLD}>
+  <NodeBase title={NodeTitles.THRESHOLD} previews={data.previews} logPreviews={data.logPreviews}>
     <Select
       nodeId={id}
       input={data.input}

--- a/ui/client/dagpipes/overview.css
+++ b/ui/client/dagpipes/overview.css
@@ -1,14 +1,8 @@
-/*
-  The only styles in this file are those tapping into react-flow internals
-  Everything else is defined in makeStyles in each file
-*/
-
 .react-flow__node-save, .react-flow__node-load,
 .react-flow__node-sum, .react-flow__node-multiply,
 .react-flow__node-filter_by_country, .react-flow__node-threshold,
 .react-flow__node-scalar_operation, .react-flow__node-mask_to_distance_field,
-.react-flow__node-select_slice
-{
+.react-flow__node-select_slice {
   font-size: 10px;
   width: 180px;
   background: #f5f5f6;
@@ -16,9 +10,14 @@
   box-shadow: 0 4px 6px -1px rgb(0 0 0 / 15%), 0 2px 4px -1px rgb(0 0 0 / 8%);
   border-radius: 2px;
   border: 1px solid #f5f5f6;
-  &.selected {
-    border-color: #BBB;
-  }
+}
+
+.react-flow__node-save.selected, .react-flow__node-load.selected,
+.react-flow__node-sum.selected, .react-flow__node-multiply.selected,
+.react-flow__node-filter_by_country.selected, .react-flow__node-threshold.selected,
+.react-flow__node-scalar_operation.selected, .react-flow__node-mask_to_distance_field.selected,
+.react-flow__node-select_slice.selected {
+  border-color: #BBB;
 }
 
 .react-flow__node-sum,
@@ -31,6 +30,22 @@
   width: 16rem;
 }
 
-.react-flow__node-filter_by_country, {
+.react-flow__node-filter_by_country {
   width: 20rem;
+}
+
+/* Spinner Styles */
+.spinner {
+  border: 4px solid rgba(0, 0, 0, 0.1);
+  border-left-color: #000;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/ui/client/index.js
+++ b/ui/client/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { store } from './dagpipes/store';
 
 import './style.css';
 
@@ -69,7 +71,11 @@ export default function Main() {
           <Route component={ViewRuns} exact path="/runs" />
           <Route component={RunSummary} exact path="/runs/:runid" />
           <Route component={RunLogs} exact path="/runlogs/:runid" />
-          <Route component={DagpipesApp} exact path="/data-modeling" />
+          <Route exact path="/data-modeling">
+            <Provider store={store}>
+              <DagpipesApp />
+            </Provider>
+          </Route>
           <Route component={AIAssistant} exact path="/ai-assistant" />
           <Route path="/*" render={() => <h2>404 Not Found</h2>} />
         </Switch>


### PR DESCRIPTION
# What's New
This is a 🚨**MAJOR**🚨 update to data modeling that enables:

1. DAG persistence after data modeling close or refresh. This allows users to navigate away and not lose their work. And, if the processing errors out, they can just go back, the DAG is still there for them to fix!
2. Previews on nodes in data modeling. This is a game changer, things are much easier to follow and debug with previews.
3. Data model validation: you can validate your DAG prior to submission.

This required a ton of changes the most important of which is a new, dedicated data modeling RQ worker which has its own isolated requirements.

### From the original PR submitted by @david-andrew:

Adds methods validation and node state preview

## Changes
- switch pydantic models to `TypedDict` since the task is called with a dictionary, not a pydantic object
- added `validate_flowcast_job` which constructs the flowcast pipeline but does not execute it. Relies on the built-in validation checks that `flowcast` runs when a pipeline is created
  - intent is that this would be run anytime the user makes a change to the graph in the data modeling editor 
  - there are potentially more validations that may be worth doing on top of instantiating the pipeline. Should probably look at errors that come up during runtime and see if any of them can be determined before the data is loaded
  - errors that cannot be caught here include any issues with data dimensions, e.g. accessing out of bounds, accessing dimensions that don't exist, etc.
- added `run_partial_flowcast_job` which will compute the result value of the given target node
  - `filter_target_node` trims all nodes in the graph that are not ancestors of the target node
  - ~~currently only returns the contents of the targeted node, not any of the intermediate steps (see todo note about how to make it return all steps)~~
  - pretty inefficient since there's no way to save any of the partial results and reuse them in the full pipeline run. `flowcast` doesn't currently support such a paradigm anyways

a pipeline (based on the built-in `flowcast` validation performed at pipeline instantiation time), and methods for generating previews of intermediate results

## TODOs
- [ ] need to set up front end call into task functions, e.g. like https://github.com/jataware/dojo/blob/main/ui/client/dagpipes/PipeEditor.js#L400-L402.
  > Note: not sure if there needs to be something that registers the `validate_flowcast_job` / `run_partial_flowcast_job` functions so the front end can call them
  - [ ] TBD what the front end interface for previewing a node will be. Perhaps something like a long hover or perhaps `ctrl-click` on a node would bring up a preview window with a preview image and the dimensions/datatype. Ideally it could make use of the xarray plot function, and perhaps plot the data or a slice. The optimal slice would depend on which dims are present, e.g. `lat`+`lon`+`time` should plot a single time slice, whereas just `time` should plot all the data over time, etc.
- [ ] test validation and partial job functions once hooked up to front end
    - [x] might need to convert the results of `run_partial_flowcast_job` from `DataArray` into something that can be sent back to the front end
- [x] make `run_partial_flowcast_job` return all the intermediate steps computed in the process.
  > Note: this should be pretty easy since the `pipe` object is available. You could pull out the data for each node in the graph, something like this:
  ```python
  def run_partial_flowcast_job(context:PreviewFlowcastContext) -> dict:
      try:
          # run partial graph, same as before
          node_id = context['node_id']
          partial_graph = filter_target_node(context['dag'], node_id)
          pipe, loaders, saved_nodes = create_pipeline({'dag': partial_graph})
          execute_pipeline(pipe, loaders, saved_nodes)
          
          # return the value of all intermediate nodes
          results = {
              node['id']: pipe.get_value(node['id']).data 
                  for node in partial_graph['nodes']
          }
          return {
              'message': 'successfully ran partial flowcast job',
              'results': results
          }
      except Exception as e:
          # same exception handling as before...
  ```
- [x] might make sense for `run_partial_flowcast_job` to generate the plot previews of the data, since this is where we have access to xarray plotting